### PR TITLE
Fix: Update linting workflow to use super-linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,18 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Lint HTML
-        uses: anmol098/w3c-html-validator@v1.1.1
-        with:
-          directory: '.' # Directory containing HTML files
-          exclude_files: '' # Comma-separated list of files to exclude
-          exclude_patterns: '' # Comma-separated list of glob patterns to exclude
-
-      - name: Lint CSS
-        uses: yokturmak/stylelint-action@v1.0.2
-        with:
-          files: '**/*.css' # Glob pattern for CSS files
-          config: | # Optional: inline stylelint config
-            {
-              "extends": "stylelint-config-standard"
-            }
+      - name: Super-Linter
+        uses: github/super-linter@v6 # Updated to v6
+        env:
+          # HTML and CSS linting are enabled by default.
+          # Stylelint will use .stylelintrc.json
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}


### PR DESCRIPTION
Replaces deprecated individual linters for HTML and CSS with github/super-linter.

- Configures super-linter to validate HTML and CSS files.
- Adds .stylelintrc.json to maintain standard stylelint configuration.