### PR TITLE
Refactor: Split build.py into smaller protocol-based modules

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,14 +4,9 @@ Builds the index.html file from configured blocks for multiple languages.
 
 import json
 import os
-import random  # Moved to top
-import re  # Moved to top
 import sys
 from typing import Any, Dict, List, Tuple, Type, TypeVar, Union
 
-from bs4 import BeautifulSoup
-from bs4.element import Tag
-from google.protobuf import json_format
 from google.protobuf.message import Message
 
 # Ensure the project root (and thus 'generated' directory) is in the Python path
@@ -38,405 +33,37 @@ Translations = Dict[str, str]
 # Define a TypeVar for generic protobuf messages
 T = TypeVar("T", bound=Message)
 
-
-def get_attribute_value_as_str(element: Tag, attr_name: str) -> str:
-    """Safely retrieves an attribute value as a string.
-    BeautifulSoup can return a list if an attribute is multi-valued,
-    but for 'data-i18n', we expect a single string.
-    """
-    attr_val: Union[str, List[str], None] = element.get(attr_name)  # Changed type hint
-    if isinstance(attr_val, list):
-        return str(attr_val[0]) if attr_val else ""
-    elif attr_val is not None:
-        return str(attr_val)
-    return ""
-
-
-def load_translations(lang: str) -> Translations:
-    """Loads translation strings for a given language."""
-    try:
-        with open(f"public/locales/{lang}.json", "r", encoding="utf-8") as f:
-            translations: Translations = json.load(f)
-            return translations
-    except FileNotFoundError:
-        print(f"Warning: Translation file for '{lang}' not found. Using default text.")
-        return {}
-    except json.JSONDecodeError:
-        print(
-            f"Warning: Could not decode JSON from locales/{lang}.json. "
-            "Using default text."
-        )
-        return {}
-
-
-def translate_html_content(html_content: str, translations: Translations) -> str:
-    """Translates data-i18n tagged elements in HTML content."""
-    if not translations:
-        return html_content
-
-    soup = BeautifulSoup(html_content, "html.parser")
-    for element in soup.find_all(attrs={"data-i18n": True}):
-        if isinstance(element, Tag):  # Ensure element is a Tag
-            key: str = get_attribute_value_as_str(element, "data-i18n")
-            if key and key in translations:  # ensure key is not empty
-                element.string = translations[key]
-            # Avoid replacing placeholders like {{...}} if key is not found
-            elif (
-                key
-                and "{{" not in element.decode_contents(formatter="html")
-                and "}}" not in element.decode_contents(formatter="html")
-            ):
-                print(
-                    f"Warning: Translation key '{key}' not found in translations for "
-                    f"current language. Element: <{element.name} "
-                    f"data-i18n='{key}'>...</{element.name}>"
-                )
-    return str(soup)
-
-
-def load_dynamic_data(data_file_path: str, message_type: Type[T]) -> List[T]:
-    """
-    Loads dynamic data from a JSON file and parses it into a list of protobuf
-    messages.
-    """
-    items: List[T] = []
-    try:
-        with open(data_file_path, "r", encoding="utf-8") as f:
-            # Assuming the JSON data is a list of dictionaries
-            data: List[Dict[str, Any]] = json.load(f)
-            for item_json in data:
-                message = message_type()
-                json_format.ParseDict(item_json, message)
-                items.append(message)
-            return items
-    except FileNotFoundError:
-        print(f"Warning: Data file {data_file_path} not found. Returning empty list.")
-        return []
-    except json.JSONDecodeError:
-        print(
-            f"Warning: Could not decode JSON from {data_file_path}. "
-            "Returning empty list."
-        )
-        return []
-    except json_format.ParseError as e:
-        print(
-            f"Warning: Could not parse JSON into protobuf for {data_file_path}: {e}. "
-            "Returning empty list."
-        )
-        return []
-    return []  # Ensure a list is always returned, even if empty due to other errors
-
-
-def load_single_item_dynamic_data(
-    data_file_path: str, message_type: Type[T]
-) -> T | None:
-    """
-    Loads dynamic data for a single item from a JSON file and parses it
-    into a protobuf message.
-    """
-    try:
-        with open(data_file_path, "r", encoding="utf-8") as f:
-            data: Dict[str, Any] = json.load(f)  # Expects a single JSON object
-            message: T = message_type()
-            json_format.ParseDict(data, message)
-            return message
-    except FileNotFoundError:
-        print(f"Warning: Data file {data_file_path} not found. Returning None.")
-        return None
-    except json.JSONDecodeError:
-        print(
-            f"Warning: Could not decode JSON from {data_file_path}. " "Returning None."
-        )
-        return None
-    except json_format.ParseError as e:
-        print(
-            f"Warning: Could not parse JSON into protobuf for {data_file_path}: {e}. "
-            "Returning None."
-        )
-        return None
-    return None
-
-
-def generate_portfolio_html(
-    items: List[PortfolioItem], translations: Translations
-) -> str:
-    """Generates HTML for portfolio items."""
-    html_output: List[str] = []
-    for item in items:
-        # PortfolioItem: id, image (Image), details (TitledBlock)
-        # Image: src, alt_text (I18nString)
-        # TitledBlock: title (I18nString), description (I18nString)
-        # I18nString: key
-        title: str = translations.get(item.details.title.key, item.details.title.key)
-        description: str = translations.get(
-            item.details.description.key, item.details.description.key
-        )
-        alt_text: str = translations.get(
-            item.image.alt_text.key, "Portfolio image"
-        )  # Default alt
-
-        html_output.append(
-            f"""
-        <div class="portfolio-item">
-            <img src="{item.image.src}" alt="{alt_text}">
-            <h3>{title}</h3>
-            <p>{description}</p>
-        </div>
-        """
-        )
-    return "\n".join(html_output)
-
-
-def generate_testimonials_html(
-    items: List[TestimonialItem], translations: Translations
-) -> str:
-    """Generates HTML for testimonial items."""
-    html_output: List[str] = []
-    for item in items:
-        # TestimonialItem: text (I18nString), author (I18nString), author_image (Image)
-        text: str = translations.get(item.text.key, item.text.key)
-        author: str = translations.get(item.author.key, item.author.key)
-        img_alt: str = translations.get(
-            item.author_image.alt_text.key, "User photo"
-        )  # Default alt text
-        html_output.append(
-            f"""
-        <div class="testimonial-item">
-            <img src="{item.author_image.src}" alt="{img_alt}">
-            <p>{text}</p>
-            <h4>{author}</h4>
-        </div>
-        """
-        )
-    return "\n".join(html_output)
-
-
-def generate_features_html(items: List[FeatureItem], translations: Translations) -> str:
-    """Generates HTML for feature items."""
-    html_output: List[str] = []
-    for item in items:
-        # FeatureItem: content (TitledBlock)
-        # TitledBlock: title (I18nString), description (I18nString)
-        title: str = translations.get(item.content.title.key, item.content.title.key)
-        description: str = translations.get(
-            item.content.description.key, item.content.description.key
-        )
-        html_output.append(
-            f"""
-        <div class="feature-item">
-            <h3>{title}</h3>
-            <p>{description}</p>
-        </div>
-        """
-        )
-    return "\n".join(html_output)
-
-
-# import random  # Moved to top
-
-
-def generate_hero_html(hero_data: HeroItem | None, translations: Translations) -> str:
-    """Generates HTML for the hero section, selecting a variation."""
-    if not hero_data or not hero_data.variations:
-        return "<!-- Hero data not found or no variations -->"
-
-    selected_variation = None
-    if hero_data.variations:
-        # Simple random selection for A/B testing.
-        # More sophisticated logic could be added here (e.g., based on build count,
-        # environment variable)
-        selected_variation = random.choice(hero_data.variations)
-
-    # Fallback to default if random selection somehow fails or
-    # if specific default is needed
-    if not selected_variation:
-        default_id = hero_data.default_variation_id
-        for var in hero_data.variations:
-            if var.variation_id == default_id:
-                selected_variation = var
-                break
-        if not selected_variation:  # If default_id not found, pick first
-            selected_variation = hero_data.variations[0]
-
-    if not selected_variation:  # Should not happen if variations exist
-        return "<!-- Could not select a hero variation -->"
-
-    # HeroItemContent: title (I18nString), subtitle (I18nString), cta (CTA)
-    title = translations.get(selected_variation.title.key, selected_variation.title.key)
-    subtitle = translations.get(
-        selected_variation.subtitle.key, selected_variation.subtitle.key
-    )
-    cta_text = translations.get(
-        selected_variation.cta.text.key, selected_variation.cta.text.key
-    )
-
-    return f"""
-    <h1>{title}</h1>
-    <p>{subtitle}</p>
-    <a href="{selected_variation.cta.link}" class="cta-button">{cta_text}</a>
-    <!-- Selected variation: {selected_variation.variation_id} -->
-    """
-
-
-def generate_contact_form_html(
-    config: ContactFormConfig | None, translations: Translations
-) -> str:
-    """
-    Generates HTML for the contact form, including data attributes for AJAX submission.
-    The actual form fields are expected to be in the block template.
-    This function primarily injects configuration.
-    """
-    if not config:
-        return "<!-- Contact form configuration not found -->"
-
-    # These will be used by the client-side JavaScript
-    return (
-        f'data-form-action-url="{config.form_action_url}"\n'
-        f'    data-success-message="{translations.get(config.success_message_key, "Message sent!")}"\n'  # noqa: E501
-        f'    data-error-message="{translations.get(config.error_message_key, "Error sending message.")}"'  # noqa: E501
-    )
-
-
-def generate_blog_html(posts: List[BlogPost], translations: Translations) -> str:
-    """Generates HTML for blog posts."""
-    html_output: List[str] = []
-    for post in posts:
-        # BlogPost: id, title (I18nString), excerpt (I18nString), cta (CTA)
-        title: str = translations.get(post.title.key, post.title.key)
-        excerpt: str = translations.get(post.excerpt.key, post.excerpt.key)
-        cta_text: str = translations.get(post.cta.text.key, post.cta.text.key)
-        html_output.append(
-            f"""
-        <div class="blog-item">
-            <h3>{title}</h3>
-            <p>{excerpt}</p>
-            <a href="{post.cta.link}" class="read-more">{cta_text}</a>
-        </div>
-        """
-        )
-    return "\n".join(html_output)
-
-
-def generate_navigation_data_for_config(
-    nav_proto: Navigation | None, translations: Translations
-) -> List[Dict[str, str]]:
-    """
-    Generates a list of navigation item dictionaries for config.json
-    based on the Navigation proto and translations.
-    """
-    nav_items_for_config: List[Dict[str, str]] = []
-    if not nav_proto:
-        return nav_items_for_config
-
-    for item in nav_proto.items:
-        label: str = translations.get(item.label.key, item.label.key)
-        nav_items_for_config.append(
-            {"label_i18n_key": item.label.key, "label": label, "href": item.href}
-        )
-    return nav_items_for_config
-
-
-def load_app_config(config_path: str = "public/config.json") -> Dict[str, Any]:
-    """Loads the main application configuration file."""
-    try:
-        with open(config_path, "r", encoding="utf-8") as f:
-            result: Dict[str, Any] = json.load(f)
-            return result
-    except FileNotFoundError:
-        print(f"Error: Configuration file {config_path} not found. Exiting.")
-        sys.exit(1)
-    except json.JSONDecodeError:
-        print(f"Error: Could not decode JSON from {config_path}. Exiting.")
-        sys.exit(1)
-
-
-def extract_base_html_parts(
-    base_html_file: str = "index.html",
-) -> Tuple[str, str, str, str]:
-    """
-    Extracts key structural parts from the base HTML file.
-
-    Returns:
-        A tuple containing:
-        - html_start: The HTML content up to and including the opening <body> tag.
-        - header_content: The content of the <header> or elements before <main>.
-        - footer_content: The content of the <footer> or elements after <main>.
-        - html_end: The closing </body> and </html> tags.
-    """
-    try:
-        with open(base_html_file, "r", encoding="utf-8") as f:
-            base_content = f.read()
-    except FileNotFoundError:
-        print(f"Error: Base HTML file '{base_html_file}' not found. Exiting.")
-        sys.exit(1)
-
-    soup = BeautifulSoup(base_content, "html.parser")
-
-    header_content_parts: List[str] = []
-    footer_content_parts: List[str] = []
-
-    body_tag = soup.body
-    if body_tag and isinstance(body_tag, Tag):
-        main_tag = body_tag.find("main")
-        if main_tag and isinstance(main_tag, Tag):
-            # Capture elements before <main> as header content
-            for element in main_tag.previous_siblings:
-                header_content_parts.append(str(element))
-            # Capture elements after <main> as footer content
-            for element in main_tag.find_next_siblings():
-                footer_content_parts.append(str(element))
-        else:
-            print(
-                f"Warning: <main> tag not found in {base_html_file}. "
-                "Header/footer content might be incomplete."
-            )
-            # Fallback: consider all direct children of <body> as potential
-            # header/footer if no <main>
-            # This part can be refined based on expected structure if <main> is missing
-    else:
-        print(
-            f"Warning: <body> tag not found in {base_html_file}. "
-            "Header/footer content might be empty."
-        )
-
-    html_tag = soup.find("html")
-    html_start: str
-    if html_tag and isinstance(html_tag, Tag):
-        # Attempt to reconstruct the part of HTML before <body>, keeping attributes
-        html_str = str(html_tag)
-        body_open_tag_index = html_str.lower().find("<body")
-        if body_open_tag_index != -1:
-            # Find where the opening body tag actually ends
-            body_tag_end_index = html_str.find(">", body_open_tag_index) + 1
-            html_start = html_str[:body_tag_end_index] + "\n"
-        else:
-            # Fallback if body tag is not found as expected
-            html_start = str(soup.find("head")) if soup.head else ""  # Or more robust
-            if not html_start:  # Minimal valid start
-                html_start = (
-                    '<!DOCTYPE html>\n<html><head><meta charset="UTF-8">'
-                    '<meta name="viewport" content="width=device-width, '
-                    'initial-scale=1.0"><title>Page</title></head><body>\n'
-                )
-    else:
-        print(
-            f"Warning: <html> tag not found in {base_html_file}. "
-            "Using default HTML structure."
-        )
-        html_start = (
-            '<!DOCTYPE html>\n<html><head><meta charset="UTF-8">'
-            '<meta name="viewport" content="width=device-width, '
-            'initial-scale=1.0"><title>Page</title></head><body>\n'
-        )
-
-    html_end: str = "\n</body>\n</html>"  # Standard closing tags
-
-    return (
-        html_start,
-        "".join(header_content_parts),
-        "".join(footer_content_parts),
-        html_end,
-    )
+# Import functions from the new translation module
+from build_protocols.translation import (  # noqa: E402
+    load_translations,
+    translate_html_content,
+)
+# Import functions from the new data_loading module
+from build_protocols.data_loading import (  # noqa: E402
+    load_dynamic_data,
+    load_single_item_dynamic_data,
+    preload_dynamic_data,
+)
+# Import functions from the new html_generation module
+from build_protocols.html_generation import (  # noqa: E402
+    generate_blog_html,
+    generate_contact_form_html,
+    generate_features_html,
+    generate_hero_html,
+    generate_portfolio_html,
+    generate_testimonials_html,
+)
+# Import functions from the new config_management module
+from build_protocols.config_management import (  # noqa: E402
+    generate_language_config,
+    generate_navigation_data_for_config,
+    load_app_config,
+)
+# Import functions from the new page_assembly module
+from build_protocols.page_assembly import (  # noqa: E402
+    assemble_translated_page,
+    extract_base_html_parts,
+)
 
 
 def main() -> None:
@@ -528,114 +155,8 @@ def main() -> None:
     print("Build process complete.")
 
 
-def preload_dynamic_data(
-    loaders_config: Dict[str, Dict[str, Any]],
-    cache: Dict[str, Union[List[Message], Message, None]],
-) -> None:
-    """Pre-loads dynamic data from JSON files into a cache."""
-    for _, config_item in loaders_config.items():
-        data_file = config_item["data_file"]
-        message_type = config_item["message_type"]
-        is_list = config_item.get("is_list", True)
-
-        if data_file not in cache:
-            if is_list:
-                cache[data_file] = load_dynamic_data(data_file, message_type)
-            else:
-                cache[data_file] = load_single_item_dynamic_data(
-                    data_file, message_type
-                )
-
-
-def generate_language_config(
-    base_app_config: Dict[str, Any],
-    nav_proto_data: Navigation | None,
-    translations: Translations,
-    # lang parameter can be used if more lang-specific logic is added later
-    lang: str,  # pylint: disable=unused-argument # Keep for potential future use
-) -> Dict[str, Any]:
-    """Generates a language-specific configuration dictionary."""
-    lang_config = base_app_config.copy()
-    lang_config["navigation"] = generate_navigation_data_for_config(
-        nav_proto_data, translations
-    )
-    # Potentially add other language-specific config overrides here
-    return lang_config
-
-
-def assemble_translated_page(  # pylint: disable=too-many-locals
-    lang: str,
-    translations: Translations,
-    html_parts: Tuple[str, str, str, str],
-    assembled_main_content: str,
-) -> str:
-    """
-    Assembles the full HTML page for a given language.
-
-    This includes:
-    - Translating i18n elements in the header and footer.
-    - Setting the 'lang' attribute on the <html> tag.
-    - Combining the HTML start, translated header, assembled main content,
-      translated footer, and HTML end.
-    """
-    html_start, header_content, footer_content, html_end = html_parts
-
-    # Translate header content
-    translated_header_soup = BeautifulSoup(header_content, "html.parser")
-    for element in translated_header_soup.find_all(attrs={"data-i18n": True}):
-        if isinstance(element, Tag):
-            key = get_attribute_value_as_str(element, "data-i18n")
-            if key and key in translations:
-                element.string = translations[key]
-
-    translated_footer_soup = BeautifulSoup(footer_content, "html.parser")
-    for element in translated_footer_soup.find_all(attrs={"data-i18n": True}):
-        if isinstance(element, Tag):
-            key = get_attribute_value_as_str(element, "data-i18n")
-            if key and key in translations:
-                element.string = translations[key]
-
-    # Set language attribute in HTML tag
-    current_html_start = html_start
-    temp_soup = BeautifulSoup(current_html_start, "html.parser")
-    html_tag_from_temp = temp_soup.find("html")
-
-    if html_tag_from_temp and isinstance(html_tag_from_temp, Tag):
-        html_tag_from_temp["lang"] = lang
-        reconstructed_start_parts = str(temp_soup).split("<body>", 1)
-        if len(reconstructed_start_parts) > 1:
-            current_html_start = reconstructed_start_parts[0] + "<body>\n"
-        else:  # Fallback if structure is unexpected (e.g. no body in html_start)
-            current_html_start = str(temp_soup)
-    else:  # Fallback if no <html> tag found in html_start
-        if "<html" in current_html_start.lower():
-            # Attempt to replace <html ...> with <html lang="lang" ...>
-            # This is a simplified approach;
-            # a more robust parser might be needed for complex cases
-            # import re # Moved to top
-            current_html_start = re.sub(
-                r"<html(\s*[^>]*)>",
-                f'<html lang="{lang}"\\1>',
-                current_html_start,
-                count=1,
-                flags=re.IGNORECASE,
-            )
-        else:  # Prepend if no html tag at all
-            current_html_start = (
-                f'<!DOCTYPE html>\n<html lang="{lang}">\n' + current_html_start
-            )
-
-    # Assemble the full page
-    page_parts = [
-        current_html_start,
-        str(translated_header_soup),
-        "<main>\n",
-        assembled_main_content,
-        "\n</main>",
-        str(translated_footer_soup),
-        html_end,
-    ]
-    return "".join(page_parts)
+# Functions preload_dynamic_data, generate_language_config, and assemble_translated_page
+# have been moved to their respective modules in build_protocols/
 
 
 def process_language_build(

--- a/build_protocols/__init__.py
+++ b/build_protocols/__init__.py
@@ -1,0 +1,10 @@
+# This file makes Python treat the directory as a package.
+# It can also be used to define what symbols are exported when
+# 'from build_protocols import *' is used, though that's not strictly necessary here.
+
+# You can also make sub-modules available more directly, e.g.:
+# from .translation import load_translations
+# from .data_loading import load_dynamic_data
+# etc.
+# For now, we'll keep it simple and rely on direct imports in build.py
+# e.g., from build_protocols.translation import load_translations

--- a/build_protocols/config_management.py
+++ b/build_protocols/config_management.py
@@ -1,0 +1,59 @@
+import json
+import sys
+from typing import Any, Dict, List
+
+# Assuming protos are compiled and available in generated.*
+# and Translations type is defined (e.g. in a shared types module or passed directly)
+from generated.nav_item_pb2 import Navigation
+
+# Type alias from build.py, consider moving to a shared types.py if more are added
+Translations = Dict[str, str]
+
+
+def load_app_config(config_path: str = "public/config.json") -> Dict[str, Any]:
+    """Loads the main application configuration file."""
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            result: Dict[str, Any] = json.load(f)
+            return result
+    except FileNotFoundError:
+        print(f"Error: Configuration file {config_path} not found. Exiting.")
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print(f"Error: Could not decode JSON from {config_path}. Exiting.")
+        sys.exit(1)
+
+
+def generate_navigation_data_for_config(
+    nav_proto: Navigation | None, translations: Translations
+) -> List[Dict[str, str]]:
+    """
+    Generates a list of navigation item dictionaries for config.json
+    based on the Navigation proto and translations.
+    """
+    nav_items_for_config: List[Dict[str, str]] = []
+    if not nav_proto:
+        return nav_items_for_config
+
+    for item in nav_proto.items:
+        label: str = translations.get(item.label.key, item.label.key)
+        nav_items_for_config.append(
+            {"label_i18n_key": item.label.key, "label": label, "href": item.href}
+        )
+    return nav_items_for_config
+
+
+def generate_language_config(
+    base_app_config: Dict[str, Any],
+    nav_proto_data: Navigation | None,
+    translations: Translations,
+    # lang parameter can be used if more lang-specific logic is added later
+    lang: str,  # pylint: disable=unused-argument # Keep for potential future use
+) -> Dict[str, Any]:
+    """Generates a language-specific configuration dictionary."""
+    lang_config = base_app_config.copy()
+    lang_config["navigation"] = generate_navigation_data_for_config(
+        nav_proto_data, translations
+    )
+    # Potentially add other language-specific config overrides here
+    return lang_config

--- a/build_protocols/data_loading.py
+++ b/build_protocols/data_loading.py
@@ -1,0 +1,92 @@
+import json
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+from google.protobuf import json_format
+from google.protobuf.message import Message
+
+# Define a TypeVar for generic protobuf messages
+T = TypeVar("T", bound=Message)
+
+
+def load_dynamic_data(data_file_path: str, message_type: Type[T]) -> List[T]:
+    """
+    Loads dynamic data from a JSON file and parses it into a list of protobuf
+    messages.
+    """
+    items: List[T] = []
+    try:
+        with open(data_file_path, "r", encoding="utf-8") as f:
+            # Assuming the JSON data is a list of dictionaries
+            data: List[Dict[str, Any]] = json.load(f)
+            for item_json in data:
+                message = message_type()
+                json_format.ParseDict(item_json, message)
+                items.append(message)
+            return items
+    except FileNotFoundError:
+        print(f"Warning: Data file {data_file_path} not found. Returning empty list.")
+        return []
+    except json.JSONDecodeError:
+        print(
+            f"Warning: Could not decode JSON from {data_file_path}. "
+            "Returning empty list."
+        )
+        return []
+    except json_format.ParseError as e:
+        print(
+            f"Warning: Could not parse JSON into protobuf for {data_file_path}: {e}. "
+            "Returning empty list."
+        )
+        return []
+    return []  # Ensure a list is always returned, even if empty due to other errors
+
+
+def load_single_item_dynamic_data(
+    data_file_path: str, message_type: Type[T]
+) -> T | None:
+    """
+    Loads dynamic data for a single item from a JSON file and parses it
+    into a protobuf message.
+    """
+    try:
+        with open(data_file_path, "r", encoding="utf-8") as f:
+            data: Dict[str, Any] = json.load(f)  # Expects a single JSON object
+            message: T = message_type()
+            json_format.ParseDict(data, message)
+            return message
+    except FileNotFoundError:
+        print(f"Warning: Data file {data_file_path} not found. Returning None.")
+        return None
+    except json.JSONDecodeError:
+        print(
+            f"Warning: Could not decode JSON from {data_file_path}. " "Returning None."
+        )
+        return None
+    except json_format.ParseError as e:
+        print(
+            f"Warning: Could not parse JSON into protobuf for {data_file_path}: {e}. "
+            "Returning None."
+        )
+        return None
+    return None
+
+
+def preload_dynamic_data(
+    loaders_config: Dict[str, Dict[str, Any]],
+    cache: Dict[str, Union[List[Message], Message, None]],
+    # Pass message_types to avoid circular dependency if they are defined elsewhere
+    # For now, assuming message_type is directly available or passed in loaders_config
+) -> None:
+    """Pre-loads dynamic data from JSON files into a cache."""
+    for _, config_item in loaders_config.items():
+        data_file = config_item["data_file"]
+        message_type = config_item["message_type"] # This comes from build.py's main config
+        is_list = config_item.get("is_list", True)
+
+        if data_file not in cache:
+            if is_list:
+                cache[data_file] = load_dynamic_data(data_file, message_type)
+            else:
+                cache[data_file] = load_single_item_dynamic_data(
+                    data_file, message_type
+                )

--- a/build_protocols/html_generation.py
+++ b/build_protocols/html_generation.py
@@ -1,0 +1,153 @@
+import random
+from typing import Any, Dict, List, Union
+
+# Assuming protos are compiled and available in generated.*
+from generated.blog_post_pb2 import BlogPost
+from generated.contact_form_config_pb2 import ContactFormConfig
+from generated.feature_item_pb2 import FeatureItem
+from generated.hero_item_pb2 import HeroItem
+from generated.portfolio_item_pb2 import PortfolioItem
+from generated.testimonial_item_pb2 import TestimonialItem
+
+# Type alias from build.py, consider moving to a shared types.py if more are added
+Translations = Dict[str, str]
+
+
+def generate_portfolio_html(
+    items: List[PortfolioItem], translations: Translations
+) -> str:
+    """Generates HTML for portfolio items."""
+    html_output: List[str] = []
+    for item in items:
+        title: str = translations.get(item.details.title.key, item.details.title.key)
+        description: str = translations.get(
+            item.details.description.key, item.details.description.key
+        )
+        alt_text: str = translations.get(
+            item.image.alt_text.key, "Portfolio image"
+        )  # Default alt
+
+        html_output.append(
+            f"""
+        <div class="portfolio-item">
+            <img src="{item.image.src}" alt="{alt_text}">
+            <h3>{title}</h3>
+            <p>{description}</p>
+        </div>
+        """
+        )
+    return "\n".join(html_output)
+
+
+def generate_testimonials_html(
+    items: List[TestimonialItem], translations: Translations
+) -> str:
+    """Generates HTML for testimonial items."""
+    html_output: List[str] = []
+    for item in items:
+        text: str = translations.get(item.text.key, item.text.key)
+        author: str = translations.get(item.author.key, item.author.key)
+        img_alt: str = translations.get(
+            item.author_image.alt_text.key, "User photo"
+        )  # Default alt text
+        html_output.append(
+            f"""
+        <div class="testimonial-item">
+            <img src="{item.author_image.src}" alt="{img_alt}">
+            <p>{text}</p>
+            <h4>{author}</h4>
+        </div>
+        """
+        )
+    return "\n".join(html_output)
+
+
+def generate_features_html(items: List[FeatureItem], translations: Translations) -> str:
+    """Generates HTML for feature items."""
+    html_output: List[str] = []
+    for item in items:
+        title: str = translations.get(item.content.title.key, item.content.title.key)
+        description: str = translations.get(
+            item.content.description.key, item.content.description.key
+        )
+        html_output.append(
+            f"""
+        <div class="feature-item">
+            <h3>{title}</h3>
+            <p>{description}</p>
+        </div>
+        """
+        )
+    return "\n".join(html_output)
+
+
+def generate_hero_html(hero_data: Union[HeroItem, None], translations: Translations) -> str:
+    """Generates HTML for the hero section, selecting a variation."""
+    if not hero_data or not hero_data.variations:
+        return "<!-- Hero data not found or no variations -->"
+
+    selected_variation = None
+    if hero_data.variations:
+        selected_variation = random.choice(hero_data.variations)
+
+    if not selected_variation:
+        default_id = hero_data.default_variation_id
+        for var in hero_data.variations:
+            if var.variation_id == default_id:
+                selected_variation = var
+                break
+        if not selected_variation and hero_data.variations: # If default_id not found, pick first
+            selected_variation = hero_data.variations[0]
+
+    if not selected_variation:
+        return "<!-- Could not select a hero variation -->"
+
+    title = translations.get(selected_variation.title.key, selected_variation.title.key)
+    subtitle = translations.get(
+        selected_variation.subtitle.key, selected_variation.subtitle.key
+    )
+    cta_text = translations.get(
+        selected_variation.cta.text.key, selected_variation.cta.text.key
+    )
+
+    return f"""
+    <h1>{title}</h1>
+    <p>{subtitle}</p>
+    <a href="{selected_variation.cta.link}" class="cta-button">{cta_text}</a>
+    <!-- Selected variation: {selected_variation.variation_id} -->
+    """
+
+
+def generate_contact_form_html(
+    config: Union[ContactFormConfig, None], translations: Translations
+) -> str:
+    """
+    Generates HTML for the contact form, including data attributes for AJAX submission.
+    """
+    if not config:
+        return "<!-- Contact form configuration not found -->"
+
+    return (
+        f'data-form-action-url="{config.form_action_url}"\n'
+        f'    data-success-message="{translations.get(config.success_message_key, "Message sent!")}"\n'
+        f'    data-error-message="{translations.get(config.error_message_key, "Error sending message.")}"'
+    )
+
+
+def generate_blog_html(posts: List[BlogPost], translations: Translations) -> str:
+    """Generates HTML for blog posts."""
+    html_output: List[str] = []
+    for post in posts:
+        title: str = translations.get(post.title.key, post.title.key)
+        excerpt: str = translations.get(post.excerpt.key, post.excerpt.key)
+        cta_text: str = translations.get(post.cta.text.key, post.cta.text.key)
+        html_output.append(
+            f"""
+        <div class="blog-item">
+            <h3>{title}</h3>
+            <p>{excerpt}</p>
+            <a href="{post.cta.link}" class="read-more">{cta_text}</a>
+        </div>
+        """
+        )
+    return "\n".join(html_output)

--- a/build_protocols/page_assembly.py
+++ b/build_protocols/page_assembly.py
@@ -1,0 +1,156 @@
+import re
+import sys
+from typing import List, Tuple, Dict
+
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+
+# Assuming Translations type is defined (e.g. in a shared types module or passed directly)
+# Assuming get_attribute_value_as_str is available, possibly from translation.py
+# For now, let's duplicate it or import if circular dependency is not an issue.
+# To avoid issues, let's assume it's passed or defined if needed, or we import it.
+# For this refactor, let's try importing from translation
+from build_protocols.translation import get_attribute_value_as_str, Translations
+
+
+def extract_base_html_parts(
+    base_html_file: str = "index.html",
+) -> Tuple[str, str, str, str]:
+    """
+    Extracts key structural parts from the base HTML file.
+
+    Returns:
+        A tuple containing:
+        - html_start: The HTML content up to and including the opening <body> tag.
+        - header_content: The content of the <header> or elements before <main>.
+        - footer_content: The content of the <footer> or elements after <main>.
+        - html_end: The closing </body> and </html> tags.
+    """
+    try:
+        with open(base_html_file, "r", encoding="utf-8") as f:
+            base_content = f.read()
+    except FileNotFoundError:
+        print(f"Error: Base HTML file '{base_html_file}' not found. Exiting.")
+        sys.exit(1)
+
+    soup = BeautifulSoup(base_content, "html.parser")
+
+    header_content_parts: List[str] = []
+    footer_content_parts: List[str] = []
+
+    body_tag = soup.body
+    if body_tag and isinstance(body_tag, Tag):
+        main_tag = body_tag.find("main")
+        if main_tag and isinstance(main_tag, Tag):
+            for element in main_tag.previous_siblings:
+                header_content_parts.append(str(element))
+            for element in main_tag.find_next_siblings():
+                footer_content_parts.append(str(element))
+        else:
+            print(
+                f"Warning: <main> tag not found in {base_html_file}. "
+                "Header/footer content might be incomplete."
+            )
+    else:
+        print(
+            f"Warning: <body> tag not found in {base_html_file}. "
+            "Header/footer content might be empty."
+        )
+
+    html_tag = soup.find("html")
+    html_start: str
+    if html_tag and isinstance(html_tag, Tag):
+        html_str = str(html_tag)
+        body_open_tag_index = html_str.lower().find("<body")
+        if body_open_tag_index != -1:
+            body_tag_end_index = html_str.find(">", body_open_tag_index) + 1
+            html_start = html_str[:body_tag_end_index] + "\n"
+        else:
+            html_start = str(soup.find("head")) if soup.head else ""
+            if not html_start:
+                html_start = (
+                    '<!DOCTYPE html>\n<html><head><meta charset="UTF-8">'
+                    '<meta name="viewport" content="width=device-width, '
+                    'initial-scale=1.0"><title>Page</title></head><body>\n'
+                )
+    else:
+        print(
+            f"Warning: <html> tag not found in {base_html_file}. "
+            "Using default HTML structure."
+        )
+        html_start = (
+            '<!DOCTYPE html>\n<html><head><meta charset="UTF-8">'
+            '<meta name="viewport" content="width=device-width, '
+            'initial-scale=1.0"><title>Page</title></head><body>\n'
+        )
+
+    html_end: str = "\n</body>\n</html>"
+
+    return (
+        html_start,
+        "".join(header_content_parts),
+        "".join(footer_content_parts),
+        html_end,
+    )
+
+
+def assemble_translated_page(  # pylint: disable=too-many-locals
+    lang: str,
+    translations: Translations, # Explicitly type Translations
+    html_parts: Tuple[str, str, str, str],
+    assembled_main_content: str,
+) -> str:
+    """
+    Assembles the full HTML page for a given language.
+    """
+    html_start, header_content, footer_content, html_end = html_parts
+
+    translated_header_soup = BeautifulSoup(header_content, "html.parser")
+    for element in translated_header_soup.find_all(attrs={"data-i18n": True}):
+        if isinstance(element, Tag):
+            key = get_attribute_value_as_str(element, "data-i18n")
+            if key and key in translations:
+                element.string = translations[key]
+
+    translated_footer_soup = BeautifulSoup(footer_content, "html.parser")
+    for element in translated_footer_soup.find_all(attrs={"data-i18n": True}):
+        if isinstance(element, Tag):
+            key = get_attribute_value_as_str(element, "data-i18n")
+            if key and key in translations:
+                element.string = translations[key]
+
+    current_html_start = html_start
+    temp_soup = BeautifulSoup(current_html_start, "html.parser")
+    html_tag_from_temp = temp_soup.find("html")
+
+    if html_tag_from_temp and isinstance(html_tag_from_temp, Tag):
+        html_tag_from_temp["lang"] = lang
+        reconstructed_start_parts = str(temp_soup).split("<body>", 1)
+        if len(reconstructed_start_parts) > 1:
+            current_html_start = reconstructed_start_parts[0] + "<body>\n"
+        else:
+            current_html_start = str(temp_soup)
+    else:
+        if "<html" in current_html_start.lower():
+            current_html_start = re.sub(
+                r"<html(\s*[^>]*)>",
+                f'<html lang="{lang}"\\1>',
+                current_html_start,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        else:
+            current_html_start = (
+                f'<!DOCTYPE html>\n<html lang="{lang}">\n' + current_html_start
+            )
+
+    page_parts = [
+        current_html_start,
+        str(translated_header_soup),
+        "<main>\n",
+        assembled_main_content,
+        "\n</main>",
+        str(translated_footer_soup),
+        html_end,
+    ]
+    return "".join(page_parts)

--- a/build_protocols/translation.py
+++ b/build_protocols/translation.py
@@ -1,0 +1,63 @@
+import json
+from typing import Dict, List, Union
+
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+
+# Type aliases
+Translations = Dict[str, str]
+
+
+def get_attribute_value_as_str(element: Tag, attr_name: str) -> str:
+    """Safely retrieves an attribute value as a string.
+    BeautifulSoup can return a list if an attribute is multi-valued,
+    but for 'data-i18n', we expect a single string.
+    """
+    attr_val: Union[str, List[str], None] = element.get(attr_name)
+    if isinstance(attr_val, list):
+        return str(attr_val[0]) if attr_val else ""
+    elif attr_val is not None:
+        return str(attr_val)
+    return ""
+
+
+def load_translations(lang: str) -> Translations:
+    """Loads translation strings for a given language."""
+    try:
+        with open(f"public/locales/{lang}.json", "r", encoding="utf-8") as f:
+            translations: Translations = json.load(f)
+            return translations
+    except FileNotFoundError:
+        print(f"Warning: Translation file for '{lang}' not found. Using default text.")
+        return {}
+    except json.JSONDecodeError:
+        print(
+            f"Warning: Could not decode JSON from locales/{lang}.json. "
+            "Using default text."
+        )
+        return {}
+
+
+def translate_html_content(html_content: str, translations: Translations) -> str:
+    """Translates data-i18n tagged elements in HTML content."""
+    if not translations:
+        return html_content
+
+    soup = BeautifulSoup(html_content, "html.parser")
+    for element in soup.find_all(attrs={"data-i18n": True}):
+        if isinstance(element, Tag):  # Ensure element is a Tag
+            key: str = get_attribute_value_as_str(element, "data-i18n")
+            if key and key in translations:  # ensure key is not empty
+                element.string = translations[key]
+            # Avoid replacing placeholders like {{...}} if key is not found
+            elif (
+                key
+                and "{{" not in element.decode_contents(formatter="html")
+                and "}}" not in element.decode_contents(formatter="html")
+            ):
+                print(
+                    f"Warning: Translation key '{key}' not found in translations for "
+                    f"current language. Element: <{element.name} "
+                    f"data-i18n='{key}'>...</{element.name}>"
+                )
+    return str(soup)

--- a/test_build.py
+++ b/test_build.py
@@ -27,10 +27,24 @@ from generated.nav_item_pb2 import Navigation  # Moved to top
 from generated.portfolio_item_pb2 import PortfolioItem
 from generated.testimonial_item_pb2 import TestimonialItem
 
-project_root = os.path.dirname(os.path.abspath(__file__))
-if project_root not in sys.path:  # This sys.path manipulation is for generated files
-    sys.path.insert(0, project_root)
+# Ensure the project root (and thus 'generated' directory) is in the Python path
+# This needs to be done BEFORE other imports from 'build' or 'build_protocols'
+_current_dir = os.path.dirname(os.path.abspath(__file__)) # This is /app for test_build.py
+_project_root_for_test = _current_dir # Assuming test_build.py is in the project root
 
+# Path to the 'generated' directory, assuming it's a sibling to test_build.py, build.py etc.
+_generated_dir_path = os.path.join(_project_root_for_test, "generated")
+
+if _project_root_for_test not in sys.path:
+    sys.path.insert(0, _project_root_for_test)
+if _generated_dir_path not in sys.path and os.path.isdir(_generated_dir_path):
+    sys.path.insert(0, _generated_dir_path)
+# This ensures that `from generated.xxx_pb2 import Xxx` works.
+
+# The following is also important from build.py to ensure build_protocols can be found
+# if build.py is in project_root and build_protocols is a subdir.
+# In this test setup, _project_root_for_test is already the top-level /app,
+# so imports like `from build_protocols.xyz` should work if /app is in sys.path.
 
 class TestBuildScript(unittest.TestCase):
     """Test cases for build.py script."""


### PR DESCRIPTION
- Created `build_protocols` directory to house new modules.
- Moved distinct functionalities (translation, data loading, HTML generation, config management, page assembly) into separate Python files within `build_protocols`.
- Updated `build.py` to delegate logic to these new modules, simplifying its role to orchestration.
- Cleaned up imports in `build.py`.
- Added `sys.path` adjustments to `test_build.py` to aid in locating generated protobuf files.

Note: Testing was hindered by an issue with populating the `generated/` directory via `npm run generate-proto` in the test environment. The Python refactoring itself is complete.