### PR TITLE
Fix test suite and linting issues

### DIFF
--- a/build_protocols/html_generation.py
+++ b/build_protocols/html_generation.py
@@ -131,7 +131,7 @@ class HeroHtmlGenerator(HtmlBlockGenerator):
         return f"""
         <h1>{title}</h1>
         <p>{subtitle}</p>
-        <a href="{selected_variation.cta.link}" class="cta-button">{cta_text}</a>
+        <a href="{selected_variation.cta.uri}" class="cta-button">{cta_text}</a>
         <!-- Selected variation: {selected_variation.variation_id} -->
         """
 
@@ -189,7 +189,7 @@ class BlogHtmlGenerator(HtmlBlockGenerator):
             <div class="blog-item" id="{post.id if post.id else ''}">
                 <h3>{title}</h3>
                 <p>{excerpt}</p>
-                <a href="{post.cta.link}" class="read-more">{cta_text}</a>
+                <a href="{post.cta.uri}" class="read-more">{cta_text}</a>
             </div>
             """
             )

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+# Ensure the project root and the 'generated' directory are in the Python path
+# so that pytest can find the main module and generated protobuf files.
+
+# Assuming conftest.py is in the project root directory /app
+_project_root = os.path.dirname(os.path.abspath(__file__))
+
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+_generated_dir = os.path.join(_project_root, "generated")
+if os.path.isdir(_generated_dir) and _generated_dir not in sys.path:
+    sys.path.insert(0, _generated_dir)
+
+print(f"PYTHONPATH for pytest (from conftest.py): {sys.path}")

--- a/test_build.py
+++ b/test_build.py
@@ -2,7 +2,6 @@ import json
 import os
 import re  # Import re module
 import shutil
-import sys
 import tempfile
 import unittest
 from unittest import mock
@@ -35,16 +34,7 @@ from generated.nav_item_pb2 import Navigation
 from generated.portfolio_item_pb2 import PortfolioItem
 from generated.testimonial_item_pb2 import TestimonialItem
 
-# Ensure the project root (and thus 'generated' directory) is in the Python path
-_current_dir = os.path.dirname(os.path.abspath(__file__))
-_project_root_for_test = _current_dir
-
-_generated_dir_path = os.path.join(_project_root_for_test, "generated")
-if _project_root_for_test not in sys.path:
-    sys.path.insert(0, _project_root_for_test)
-if _generated_dir_path not in sys.path and os.path.isdir(_generated_dir_path):
-    sys.path.insert(0, _generated_dir_path)
-
+# sys.path modification moved to conftest.py
 
 class TestBuildScript(unittest.TestCase):
     """Test cases for build.py script components and main execution."""
@@ -644,7 +634,7 @@ class TestBuildScript(unittest.TestCase):
             variations=[HeroItemContent(variation_id="v1", title={"key": "htk"})],
         )
         mock_contact_config = ContactFormConfig(
-            form_action_url="/test_action",
+            form_action_uri="/test_action",  # Changed form_action_url to form_action_uri
             success_message_key="contact_success",
             error_message_key="contact_error",
         )


### PR DESCRIPTION
- Resolved Python import errors in tests for generated protobufs by using conftest.py to manage sys.path.
- Installed missing runtime dependency (bs4) by ensuring requirements.txt is processed.
- Fixed AttributeError in HTML generation for blog and hero blocks by using `cta.uri` instead of `cta.link`.
- Corrected ValueError in test mock for ContactFormConfig by using the correct field name `form_action_uri`.
- Ran linters (ruff, mypy) and fixed reported import sorting and unused import issues.