### PR TITLE
Fix: Correct header element order in HTML generation

### DIFF
--- a/build.py
+++ b/build.py
@@ -380,8 +380,10 @@ def extract_base_html_parts(
         main_tag = body_tag.find("main")
         if main_tag and isinstance(main_tag, Tag):
             # Capture elements before <main> as header content
-            for element in main_tag.previous_siblings:
+            for element in main_tag.previous_siblings:  # Iterates in reverse document order
                 header_content_parts.append(str(element))
+            header_content_parts.reverse()  # Correct the order of header parts
+
             # Capture elements after <main> as footer content
             for element in main_tag.find_next_siblings():
                 footer_content_parts.append(str(element))


### PR DESCRIPTION
The `extract_base_html_parts` function in `build.py` was collecting header elements in reverse order due to how `previous_siblings` iterates. This change adds a `reverse()` call to ensure the header elements are in the correct document order.

This fixes an issue where `npm run format` would report HTML syntax errors (like 'Unexpected closing tag "body"') in the generated `index.html` and `index_es.html` files, likely due to BeautifulSoup's handling and re-serialization of the malformed header structure during translation and assembly.