### PR TITLE
Refactor: Switch build system to Jinja2, remove BeautifulSoup

### DIFF
--- a/build.py
+++ b/build.py
@@ -117,7 +117,7 @@ class BuildOrchestrator:
         lang: str,
         default_lang: str,
         # html_parts is no longer used directly in the same way
-        _html_parts: tuple[str, str, str, str], # Marked as unused
+        _html_parts: tuple[str, str, str, str],  # Marked as unused
         dynamic_data_loaders_config: Dict[str, Dict[str, Any]],
         static_header_html: str,
         static_footer_html: str,
@@ -146,14 +146,13 @@ class BuildOrchestrator:
         # Add specific page titles per language if defined, e.g. "page_title_landing_es"
         page_title = translations.get(f"page_title_landing_{lang}", page_title)
 
-
         full_html_content = self.page_builder.assemble_translated_page(
             lang=lang,
             translations=translations,
-            html_parts=("", "", "", ""), # Dummy value, DefaultPageBuilder ignores this
+            html_parts=("", "", "", ""),  # Dummy value, DefaultPageBuilder ignores this
             main_content=assembled_main_content,
-            header_content=translated_header, # Passed to Jinja context for base.html
-            footer_content=translated_footer, # Passed to Jinja context for base.html
+            header_content=translated_header,  # Passed to Jinja context for base.html
+            footer_content=translated_footer,  # Passed to Jinja context for base.html
             page_title=page_title,
         )
 
@@ -236,7 +235,7 @@ class BuildOrchestrator:
             self._process_language(
                 lang=lang,
                 default_lang=default_lang,
-                _html_parts=dummy_html_parts, # Pass dummy value
+                _html_parts=dummy_html_parts,  # Pass dummy value
                 dynamic_data_loaders_config=dynamic_data_loaders_config,
                 static_header_html=static_header_html,
                 static_footer_html=static_footer_html,
@@ -383,7 +382,6 @@ class BuildOrchestrator:
                         # For single items, if data_items is None, pass None to generator
                         pass
 
-
                     # HtmlBlockGenerator now handles its own template loading & rendering
                     generated_html_for_block = html_generator.generate_html(
                         data_items, translations
@@ -395,7 +393,9 @@ class BuildOrchestrator:
                     # templates/blocks/ directly if it's purely static.
                     # Or, this is an error in configuration.
                     # For now, we'll just log a warning if a block has no generator.
-                    print(f"Warning: No HTML generator found for block: {block_file_name}. Skipping data injection.")
+                    print(
+                        f"Warning: No HTML generator found for block: {block_file_name}. Skipping data injection."
+                    )
                     # Attempt to read static block content if needed, but this wasn't the old behavior.
                     # The old behavior relied on a placeholder for replacement.
                     # With Jinja, if a block is purely static, its template would just be static HTML.
@@ -423,15 +423,22 @@ class BuildOrchestrator:
                     # Let's replicate that if no generator is found but block is in config.
                     # This means the block is treated as mostly static HTML but with i18n tags.
                     try:
-                        block_template_path = os.path.join("templates", "blocks", block_file_name) # new path
-                        with open(block_template_path, "r", encoding="utf-8") as block_file:
+                        block_template_path = os.path.join(
+                            "templates", "blocks", block_file_name
+                        )  # new path
+                        with open(
+                            block_template_path, "r", encoding="utf-8"
+                        ) as block_file:
                             static_block_content = block_file.read()
                         generated_html_for_block = static_block_content
-                        print(f"Info: Treating block {block_file_name} as static HTML for translation only.")
+                        print(
+                            f"Info: Treating block {block_file_name} as static HTML for translation only."
+                        )
                     except FileNotFoundError:
-                         print(f"Warning: Static block file {block_template_path} not found. Skipping.")
-                         continue
-
+                        print(
+                            f"Warning: Static block file {block_file_name} not found. Skipping."
+                        )
+                        continue
 
                 # The translation of the entire block's generated HTML
                 # should ideally be handled by the Jinja templates themselves if they use
@@ -461,8 +468,10 @@ class BuildOrchestrator:
                 # So, `generated_html_for_block` should be final.
                 blocks_html_parts.append(generated_html_for_block)
 
-            except FileNotFoundError: # This would now be an issue with Jinja's loader
-                print(f"Warning: Template for block {block_file_name} not found by Jinja. Skipping.")
+            except FileNotFoundError:  # This would now be an issue with Jinja's loader
+                print(
+                    f"Warning: Template for block {block_file_name} not found by Jinja. Skipping."
+                )
             except Exception as e:
                 print(
                     f"Error processing block {block_file_name} for lang {lang}: "

--- a/build.py
+++ b/build.py
@@ -9,6 +9,7 @@ import sys
 from typing import Any, Dict, List, Optional
 
 from google.protobuf.message import Message
+from jinja2 import Environment, FileSystemLoader
 
 # Ensure the project root (and thus 'generated' directory) is in the Python path
 # This allows for direct execution of this script.
@@ -115,20 +116,24 @@ class BuildOrchestrator:
         self,
         lang: str,
         default_lang: str,
-        html_parts: tuple[str, str, str, str],
+        # html_parts is no longer used directly in the same way
+        _html_parts: tuple[str, str, str, str], # Marked as unused
         dynamic_data_loaders_config: Dict[str, Dict[str, Any]],
+        static_header_html: str,
+        static_footer_html: str,
     ) -> None:
         """Processes and builds the page for a single language."""
         print(f"Processing language: {lang}")
         translations = self.translation_provider.load_translations(lang)
 
-        _html_start, original_header_html, original_footer_html, _html_end = html_parts
-
+        # Translate static header and footer content
+        # These are passed to base.html, which might have its own i18n structure too.
+        # For content within these strings, direct translation is applied.
         translated_header = self.translation_provider.translate_html_content(
-            original_header_html, translations
+            static_header_html, translations
         )
         translated_footer = self.translation_provider.translate_html_content(
-            original_footer_html, translations
+            static_footer_html, translations
         )
 
         self._generate_language_specific_config(lang, translations)
@@ -137,13 +142,19 @@ class BuildOrchestrator:
             lang, translations, dynamic_data_loaders_config
         )
 
+        page_title = translations.get("page_title_default", "Simple Landing Page")
+        # Add specific page titles per language if defined, e.g. "page_title_landing_es"
+        page_title = translations.get(f"page_title_landing_{lang}", page_title)
+
+
         full_html_content = self.page_builder.assemble_translated_page(
             lang=lang,
             translations=translations,
-            html_parts=html_parts,
+            html_parts=("", "", "", ""), # Dummy value, DefaultPageBuilder ignores this
             main_content=assembled_main_content,
-            header_content=translated_header,
-            footer_content=translated_footer,
+            header_content=translated_header, # Passed to Jinja context for base.html
+            footer_content=translated_footer, # Passed to Jinja context for base.html
+            page_title=page_title,
         )
 
         output_filename = f"index_{lang}.html"
@@ -171,12 +182,64 @@ class BuildOrchestrator:
 
         os.makedirs("public/generated_configs", exist_ok=True)
 
-        base_html_path = self.app_config.get("base_html_file", "index.html")
-        html_parts = self.page_builder.extract_base_html_parts(base_html_path)
+        # base_html_path is no longer needed to extract parts by PageBuilder
+        # html_parts from page_builder.extract_base_html_parts is also not needed in the new way
+        # However, we need the static header and footer content.
+        # For this refactor, we'll define them as static strings.
+        # In a more complex app, these could come from separate files or Jinja includes.
+
+        # Manually define static header and footer content based on original index.html
+        # This is a simplified approach for the refactor.
+        # Ideally, these would be managed as separate small templates or includes if complex.
+        static_header_html = """
+    <header>
+      <nav>
+        <div class="logo">
+          <a href="#">Logo</a>
+        </div>
+        <button
+          aria-expanded="false"
+          aria-label="Toggle menu"
+          class="hamburger-menu"
+        >
+          <span class="hamburger-bar"></span>
+          <span class="hamburger-bar"></span>
+          <span class="hamburger-bar"></span>
+        </button>
+        <div class="nav-items">
+          <ul>
+            <!-- Navigation items will be dynamically injected here by client-side JS -->
+          </ul>
+          <button aria-label="Switch to Dark Mode" id="dark-mode-toggle">
+            🌙
+          </button>
+          <div id="language-switcher">
+            <button data-lang="en">EN</button>
+            <button data-lang="es">ES</button>
+          </div>
+        </div>
+      </nav>
+    </header>
+        """
+        static_footer_html = """
+    <footer>
+      <p data-i18n="footer_text">
+        &amp;copy; 2023 Simple Landing Page. All rights reserved.
+      </p>
+    </footer>
+        """
+        # Dummy html_parts to satisfy the _process_language signature that still expects it
+        # This parameter in _process_language should be removed or refactored further.
+        dummy_html_parts = ("", "", "", "")
 
         for lang in supported_langs:
             self._process_language(
-                lang, default_lang, html_parts, dynamic_data_loaders_config
+                lang=lang,
+                default_lang=default_lang,
+                _html_parts=dummy_html_parts, # Pass dummy value
+                dynamic_data_loaders_config=dynamic_data_loaders_config,
+                static_header_html=static_header_html,
+                static_footer_html=static_footer_html,
             )
 
         print("Build process complete.")
@@ -299,13 +362,12 @@ class BuildOrchestrator:
                 )
                 continue
 
+            # The concept of reading block template content directly and replacing placeholders
+            # is now handled by Jinja2 within each HtmlBlockGenerator.
+            # The generators will use their Jinja environment to load templates from
+            # `templates/blocks/`
+            generated_html_for_block = ""
             try:
-                block_template_path = os.path.join("blocks", block_file_name)
-                with open(block_template_path, "r", encoding="utf-8") as block_file:
-                    block_template_content = block_file.read()
-
-                block_content_with_data = block_template_content
-
                 if (
                     block_file_name in data_loaders_config
                     and block_file_name in self.html_generators
@@ -313,32 +375,95 @@ class BuildOrchestrator:
                     loader_cfg = data_loaders_config[block_file_name]
                     html_generator = self.html_generators[block_file_name]
 
+                    # Data loading remains the same
                     data_items: Any = self.data_cache.get_item(loader_cfg["data_file"])
-
                     if loader_cfg.get("is_list", True) and data_items is None:
                         data_items = []
+                    elif not loader_cfg.get("is_list", True) and data_items is None:
+                        # For single items, if data_items is None, pass None to generator
+                        pass
 
+
+                    # HtmlBlockGenerator now handles its own template loading & rendering
                     generated_html_for_block = html_generator.generate_html(
                         data_items, translations
                     )
+                else:
+                    # If block is not in html_generators, it might be a simple static block
+                    # This path needs clarification: for now, assume all configured blocks
+                    # have a generator. If not, we might need to read its content from
+                    # templates/blocks/ directly if it's purely static.
+                    # Or, this is an error in configuration.
+                    # For now, we'll just log a warning if a block has no generator.
+                    print(f"Warning: No HTML generator found for block: {block_file_name}. Skipping data injection.")
+                    # Attempt to read static block content if needed, but this wasn't the old behavior.
+                    # The old behavior relied on a placeholder for replacement.
+                    # With Jinja, if a block is purely static, its template would just be static HTML.
+                    # The current HtmlBlockGenerators expect data.
+                    # This logic branch might need to be removed or adapted if static blocks
+                    # without data are listed in app_config['blocks'].
+                    # For now, we assume blocks in app_config['blocks'] are dynamic and have generators.
+                    # If a block is purely static HTML, it should be part of the main base.html
+                    # or a Jinja include there, not processed via this loop.
 
-                    block_content_with_data = block_template_content.replace(
-                        loader_cfg["placeholder"], generated_html_for_block
-                    )
+                    # Fallback: try to load the block as a static template if no generator
+                    # This is a deviation, as the old code expected a generator to fill a placeholder.
+                    # If it's a static block, it would have been included directly.
+                    # This part might be an over-correction.
+                    # Let's stick to: if it's in 'blocks' config, it should have a generator.
+                    # If a block is purely static, it shouldn't be in 'blocks' config for this loop.
+                    # It should be part of the base.html or included there.
+                    # The original code read the file content and then potentially replaced a placeholder.
+                    # If no placeholder replacement, it used the content as is.
+                    # With Jinja generators, the generator IS the one loading the template.
+                    # So, if a block is in config, it MUST have a generator.
 
-                translated_block_html = (
-                    self.translation_provider.translate_html_content(
-                        block_content_with_data, translations
-                    )
-                )
-                blocks_html_parts.append(translated_block_html)
+                    # The old code would read the block file, then if no generator,
+                    # it would still try to translate the raw content.
+                    # Let's replicate that if no generator is found but block is in config.
+                    # This means the block is treated as mostly static HTML but with i18n tags.
+                    try:
+                        block_template_path = os.path.join("templates", "blocks", block_file_name) # new path
+                        with open(block_template_path, "r", encoding="utf-8") as block_file:
+                            static_block_content = block_file.read()
+                        generated_html_for_block = static_block_content
+                        print(f"Info: Treating block {block_file_name} as static HTML for translation only.")
+                    except FileNotFoundError:
+                         print(f"Warning: Static block file {block_template_path} not found. Skipping.")
+                         continue
 
-            except FileNotFoundError:
-                print(f"Warning: Block file {block_template_path} not found. Skipping.")
-            except Exception as e:  # pylint: disable=broad-except
-                # Catching general Exception to ensure one block's failure
-                # doesn't stop the entire build for a language.
-                # Consider more specific exceptions if error handling needs refinement.
+
+                # The translation of the entire block's generated HTML
+                # should ideally be handled by the Jinja templates themselves if they use
+                # the `translations` context properly.
+                # If `translate_html_content` is still needed here, it implies that
+                # the generated HTML from blocks might *still* contain {{i18n_key}} tags
+                # that Jinja didn't process (e.g. if they were part of string literals
+                # within the protobuf data that got directly embedded).
+                # This should be minimized; translations should occur within Jinja templates.
+                # For safety, we can keep it, but it might indicate a smell.
+                # The Jinja templates for blocks now receive `translations` object, so they *should*
+                # be doing all necessary translations.
+                # Let's assume the block HTML from generator is fully translated.
+                # If not, `translate_html_content` would be needed here.
+                # The original code did this translation *after* placeholder replacement.
+
+                # If HtmlBlockGenerator.generate_html already returns fully translated HTML
+                # (because Jinja templates use the `translations` object), then this
+                # `translate_html_content` call might be redundant or even harmful
+                # if it re-processes already translated content.
+                # Let's assume for now that generators output translated content.
+                # The `base.html` itself will handle its own i18n via client-side.
+                # Server-side translation of `base.html` structure is done by passing `translations` to its context.
+
+                # Decision: The individual block templates are responsible for their own translation
+                # using the `translations` object passed to them.
+                # So, `generated_html_for_block` should be final.
+                blocks_html_parts.append(generated_html_for_block)
+
+            except FileNotFoundError: # This would now be an issue with Jinja's loader
+                print(f"Warning: Template for block {block_file_name} not found by Jinja. Skipping.")
+            except Exception as e:
                 print(
                     f"Error processing block {block_file_name} for lang {lang}: "
                     f"{e}. Skipping."
@@ -373,6 +498,11 @@ def main() -> None:
     loaders, etc.) and then invokes the BuildOrchestrator to perform the
     website build.
     """
+    # Initialize Jinja2 Environment
+    jinja_env = Environment(
+        loader=FileSystemLoader("templates"), autoescape=True  # Enable autoescaping
+    )
+
     # Instantiate service components with more descriptive names
     app_config_manager_instance = DefaultAppConfigManager()
     translation_provider_instance = DefaultTranslationProvider()
@@ -381,18 +511,19 @@ def main() -> None:
     data_loader_instance = JsonProtoDataLoader[Message]()
     data_cache_instance = InMemoryDataCache[Message]()
     page_builder_instance = DefaultPageBuilder(
-        translation_provider=translation_provider_instance
+        translation_provider=translation_provider_instance,
+        jinja_env=jinja_env,  # Pass env to PageBuilder
     )
 
     # Map block filenames to their specific HTML generator instances
-    # Formatted for line length.
+    # Pass jinja_env to each generator
     html_generator_instances: Dict[str, HtmlBlockGenerator] = {
-        "portfolio.html": PortfolioHtmlGenerator(),
-        "blog.html": BlogHtmlGenerator(),
-        "features.html": FeaturesHtmlGenerator(),
-        "testimonials.html": TestimonialsHtmlGenerator(),
-        "hero.html": HeroHtmlGenerator(),
-        "contact-form.html": ContactFormHtmlGenerator(),
+        "portfolio.html": PortfolioHtmlGenerator(jinja_env=jinja_env),
+        "blog.html": BlogHtmlGenerator(jinja_env=jinja_env),
+        "features.html": FeaturesHtmlGenerator(jinja_env=jinja_env),
+        "testimonials.html": TestimonialsHtmlGenerator(jinja_env=jinja_env),
+        "hero.html": HeroHtmlGenerator(jinja_env=jinja_env),
+        "contact-form.html": ContactFormHtmlGenerator(jinja_env=jinja_env),
     }
 
     # Create and run the orchestrator

--- a/build_protocols/html_generation.py
+++ b/build_protocols/html_generation.py
@@ -106,7 +106,9 @@ class HeroHtmlGenerator(HtmlBlockGenerator):
         Returns:
             An HTML string for the hero section.
         """
-        selected_variation: Optional[HeroItemContent] = None  # Define type once at the correct scope
+        selected_variation: Optional[HeroItemContent] = (
+            None  # Define type once at the correct scope
+        )
 
         if not data or not data.variations:
             # selected_variation remains None, which is handled by the template
@@ -126,7 +128,9 @@ class HeroHtmlGenerator(HtmlBlockGenerator):
 
         template = self.jinja_env.get_template("blocks/hero.html")
         # The template expects `hero_item` as the context variable for the selected variation
-        return str(template.render(hero_item=selected_variation, translations=translations))
+        return str(
+            template.render(hero_item=selected_variation, translations=translations)
+        )
 
 
 class ContactFormHtmlGenerator(HtmlBlockGenerator):

--- a/build_protocols/html_generation.py
+++ b/build_protocols/html_generation.py
@@ -43,7 +43,7 @@ class PortfolioHtmlGenerator(HtmlBlockGenerator):
             An HTML string representing the portfolio items.
         """
         template = self.jinja_env.get_template("blocks/portfolio.html")
-        return template.render(items=data, translations=translations)
+        return str(template.render(items=data, translations=translations))
 
 
 class TestimonialsHtmlGenerator(HtmlBlockGenerator):
@@ -65,7 +65,7 @@ class TestimonialsHtmlGenerator(HtmlBlockGenerator):
             An HTML string representing the testimonial items.
         """
         template = self.jinja_env.get_template("blocks/testimonials.html")
-        return template.render(items=data, translations=translations)
+        return str(template.render(items=data, translations=translations))
 
 
 class FeaturesHtmlGenerator(HtmlBlockGenerator):
@@ -85,7 +85,7 @@ class FeaturesHtmlGenerator(HtmlBlockGenerator):
             An HTML string representing the feature items.
         """
         template = self.jinja_env.get_template("blocks/features.html")
-        return template.render(items=data, translations=translations)
+        return str(template.render(items=data, translations=translations))
 
 
 class HeroHtmlGenerator(HtmlBlockGenerator):
@@ -106,24 +106,27 @@ class HeroHtmlGenerator(HtmlBlockGenerator):
         Returns:
             An HTML string for the hero section.
         """
+        selected_variation: Optional[HeroItemContent] = None  # Define type once at the correct scope
+
         if not data or not data.variations:
-            # This case should ideally be handled by the template,
-            # but can be pre-checked.
-            # For simplicity, passing None to template if no data.
-            selected_variation = None
+            # selected_variation remains None, which is handled by the template
+            pass
         else:
-            selected_variation: Optional[HeroItemContent] = None
+            # Attempt to find and set the selected_variation
             if data.default_variation_id:
                 for var in data.variations:
                     if var.variation_id == data.default_variation_id:
                         selected_variation = var
                         break
+
+            # If no specific variation was found yet (e.g. default_variation_id didn't match or wasn't set)
+            # and variations are available, pick one randomly.
             if not selected_variation and data.variations:
                 selected_variation = random.choice(data.variations)
 
         template = self.jinja_env.get_template("blocks/hero.html")
         # The template expects `hero_item` as the context variable for the selected variation
-        return template.render(hero_item=selected_variation, translations=translations)
+        return str(template.render(hero_item=selected_variation, translations=translations))
 
 
 class ContactFormHtmlGenerator(HtmlBlockGenerator):
@@ -146,7 +149,7 @@ class ContactFormHtmlGenerator(HtmlBlockGenerator):
         """
         template = self.jinja_env.get_template("blocks/contact-form.html")
         # The template expects `config` for the ContactFormConfig data
-        return template.render(config=data, translations=translations)
+        return str(template.render(config=data, translations=translations))
 
 
 class BlogHtmlGenerator(HtmlBlockGenerator):
@@ -166,4 +169,4 @@ class BlogHtmlGenerator(HtmlBlockGenerator):
             An HTML string representing the blog posts.
         """
         template = self.jinja_env.get_template("blocks/blog.html")
-        return template.render(items=data, translations=translations)
+        return str(template.render(items=data, translations=translations))

--- a/build_protocols/html_generation.py
+++ b/build_protocols/html_generation.py
@@ -9,8 +9,9 @@ and produces an HTML string representation for that block.
 """
 
 import random
-import textwrap
 from typing import List, Optional
+
+from jinja2 import Environment
 
 # Generated protobuf message types
 from generated.blog_post_pb2 import BlogPost
@@ -24,7 +25,10 @@ from .interfaces import HtmlBlockGenerator, Translations
 
 
 class PortfolioHtmlGenerator(HtmlBlockGenerator):
-    """Generates HTML for a list of portfolio items."""
+    """Generates HTML for a list of portfolio items using Jinja2."""
+
+    def __init__(self, jinja_env: Environment):
+        self.jinja_env = jinja_env
 
     def generate_html(
         self, data: List[PortfolioItem], translations: Translations
@@ -36,35 +40,17 @@ class PortfolioHtmlGenerator(HtmlBlockGenerator):
             translations: A dictionary containing translations.
 
         Returns:
-            An HTML string representing the portfolio items, or an empty
-            string if no data is provided.
+            An HTML string representing the portfolio items.
         """
-        if not data:
-            return ""
-        html_output: List[str] = []
-        for item in data:
-            title: str = translations.get(
-                item.details.title.key, item.details.title.key
-            )
-            description: str = translations.get(
-                item.details.description.key, item.details.description.key
-            )
-            alt_text: str = translations.get(item.image.alt_text.key, "Portfolio image")
-
-            html_output.append(
-                textwrap.dedent(f"""\
-                    <div class="portfolio-item" id="{item.id if item.id else ""}">
-                        <img src="{item.image.src}" alt="{alt_text}">
-                        <h3>{title}</h3>
-                        <p>{description}</p>
-                    </div>
-                """)
-            )
-        return "\n".join(html_output)
+        template = self.jinja_env.get_template("blocks/portfolio.html")
+        return template.render(items=data, translations=translations)
 
 
 class TestimonialsHtmlGenerator(HtmlBlockGenerator):
-    """Generates HTML for a list of testimonial items."""
+    """Generates HTML for a list of testimonial items using Jinja2."""
+
+    def __init__(self, jinja_env: Environment):
+        self.jinja_env = jinja_env
 
     def generate_html(
         self, data: List[TestimonialItem], translations: Translations
@@ -76,32 +62,17 @@ class TestimonialsHtmlGenerator(HtmlBlockGenerator):
             translations: A dictionary containing translations.
 
         Returns:
-            An HTML string representing the testimonial items, or an empty
-            string if no data is provided.
+            An HTML string representing the testimonial items.
         """
-        if not data:
-            return ""
-        html_output: List[str] = []
-        for item in data:
-            text: str = translations.get(item.text.key, item.text.key)
-            author: str = translations.get(item.author.key, item.author.key)
-            img_alt: str = translations.get(
-                item.author_image.alt_text.key, "User photo"
-            )
-            html_output.append(
-                textwrap.dedent(f"""\
-                    <div class="testimonial-item">
-                        <img src="{item.author_image.src}" alt="{img_alt}">
-                        <p>"{text}"</p>
-                        <h4>{author}</h4>
-                    </div>
-                """)
-            )
-        return "\n".join(html_output)
+        template = self.jinja_env.get_template("blocks/testimonials.html")
+        return template.render(items=data, translations=translations)
 
 
 class FeaturesHtmlGenerator(HtmlBlockGenerator):
-    """Generates HTML for a list of feature items."""
+    """Generates HTML for a list of feature items using Jinja2."""
+
+    def __init__(self, jinja_env: Environment):
+        self.jinja_env = jinja_env
 
     def generate_html(self, data: List[FeatureItem], translations: Translations) -> str:
         """Generates HTML markup for feature items.
@@ -111,137 +82,78 @@ class FeaturesHtmlGenerator(HtmlBlockGenerator):
             translations: A dictionary containing translations.
 
         Returns:
-            An HTML string representing the feature items, or an empty
-            string if no data is provided.
+            An HTML string representing the feature items.
         """
-        if not data:
-            return ""
-        html_output: List[str] = []
-        for item in data:
-            title: str = translations.get(
-                item.content.title.key, item.content.title.key
-            )
-            description: str = translations.get(
-                item.content.description.key, item.content.description.key
-            )
-            # Icon handling: Assumes icon.svg_content contains raw SVG if present.
-            icon_html = ""
-            if (
-                hasattr(item, "icon")  # Check if icon field exists
-                and item.icon  # Check if icon message is set
-                and hasattr(
-                    item.icon, "svg_content"
-                )  # Check if svg_content field exists
-                and item.icon.svg_content  # Check if svg_content has a value
-            ):
-                icon_html = item.icon.svg_content
-
-            html_output.append(
-                textwrap.dedent(f"""\
-                    <div class="feature-item">
-                        {icon_html}
-                        <h3>{title}</h3>
-                        <p>{description}</p>
-                    </div>
-                """)
-            )
-        return "\n".join(html_output)
+        template = self.jinja_env.get_template("blocks/features.html")
+        return template.render(items=data, translations=translations)
 
 
 class HeroHtmlGenerator(HtmlBlockGenerator):
-    """Generates HTML for a hero section, possibly with variations."""
+    """Generates HTML for a hero section using Jinja2."""
+
+    def __init__(self, jinja_env: Environment):
+        self.jinja_env = jinja_env
 
     def generate_html(
         self, data: Optional[HeroItem], translations: Translations
     ) -> str:
         """Generates HTML for the hero section, selecting a variation.
 
-        If a default variation ID is specified in the data and found, it's used.
-        Otherwise, if variations exist, one is chosen randomly.
-
         Args:
             data: An optional HeroItem protobuf message.
             translations: A dictionary containing translations.
 
         Returns:
-            An HTML string for the hero section, or an HTML comment indicating
-            missing data or inability to select a variation.
+            An HTML string for the hero section.
         """
         if not data or not data.variations:
-            return "<!-- Hero data not found or no variations -->"
+            # This case should ideally be handled by the template,
+            # but can be pre-checked.
+            # For simplicity, passing None to template if no data.
+            selected_variation = None
+        else:
+            selected_variation: Optional[HeroItemContent] = None
+            if data.default_variation_id:
+                for var in data.variations:
+                    if var.variation_id == data.default_variation_id:
+                        selected_variation = var
+                        break
+            if not selected_variation and data.variations:
+                selected_variation = random.choice(data.variations)
 
-        selected_variation: Optional[HeroItemContent] = None
-
-        if data.default_variation_id:
-            for var in data.variations:
-                if var.variation_id == data.default_variation_id:
-                    selected_variation = var
-                    break
-
-        if not selected_variation and data.variations:
-            selected_variation = random.choice(data.variations)
-
-        if not selected_variation:
-            return "<!-- Could not select a hero variation -->"
-
-        title = translations.get(
-            selected_variation.title.key, selected_variation.title.key
-        )
-        subtitle = translations.get(
-            selected_variation.subtitle.key, selected_variation.subtitle.key
-        )
-        cta_text = translations.get(
-            selected_variation.cta.text.key, selected_variation.cta.text.key
-        )
-
-        return textwrap.dedent(f"""\
-            <h1>{title}</h1>
-            <p>{subtitle}</p>
-            <a href="{selected_variation.cta.uri}" class="cta-button">{cta_text}</a>
-            <!-- Selected variation: {selected_variation.variation_id} -->
-        """)
+        template = self.jinja_env.get_template("blocks/hero.html")
+        # The template expects `hero_item` as the context variable for the selected variation
+        return template.render(hero_item=selected_variation, translations=translations)
 
 
 class ContactFormHtmlGenerator(HtmlBlockGenerator):
-    """Generates HTML data attributes string for a contact form."""
+    """Generates HTML for a contact form section using Jinja2."""
+
+    def __init__(self, jinja_env: Environment):
+        self.jinja_env = jinja_env
 
     def generate_html(
         self, data: Optional[ContactFormConfig], translations: Translations
     ) -> str:
-        """Generates a string of HTML data attributes for the contact form.
-
-        This generator is intended to produce attributes that can be merged
-        into an existing <form> tag in a template.
+        """Generates HTML markup for the contact form section.
 
         Args:
             data: An optional ContactFormConfig protobuf message.
             translations: A dictionary containing translations.
 
         Returns:
-            A string of HTML attributes, or an HTML comment if configuration
-            is not found.
+            An HTML string representing the contact form section.
         """
-        if not data:
-            return "<!-- Contact form configuration not found -->"
-
-        attrs = []
-        if data.form_action_uri:
-            attrs.append(f'action="{data.form_action_uri}"')
-
-        # These data attributes are for client-side JavaScript to use.
-        attrs.append(f'data-form-action-url="{data.form_action_uri}"')
-        attrs.append(
-            f'data-success-message="{translations.get(data.success_message_key, "Message sent!")}"'
-        )
-        attrs.append(
-            f'data-error-message="{translations.get(data.error_message_key, "Error sending message.")}"'
-        )
-        attrs.append('method="POST"')  # Standard method for form submission
-        return " ".join(attrs)
+        template = self.jinja_env.get_template("blocks/contact-form.html")
+        # The template expects `config` for the ContactFormConfig data
+        return template.render(config=data, translations=translations)
 
 
 class BlogHtmlGenerator(HtmlBlockGenerator):
-    """Generates HTML for a list of blog posts."""
+    """Generates HTML for a list of blog posts using Jinja2."""
+
+    def __init__(self, jinja_env: Environment):
+        self.jinja_env = jinja_env
 
     def generate_html(self, data: List[BlogPost], translations: Translations) -> str:
         """Generates HTML markup for blog posts.
@@ -251,23 +163,7 @@ class BlogHtmlGenerator(HtmlBlockGenerator):
             translations: A dictionary containing translations.
 
         Returns:
-            An HTML string representing the blog posts, or an empty
-            string if no data is provided.
+            An HTML string representing the blog posts.
         """
-        if not data:
-            return ""
-        html_output: List[str] = []
-        for post in data:
-            title: str = translations.get(post.title.key, post.title.key)
-            excerpt: str = translations.get(post.excerpt.key, post.excerpt.key)
-            cta_text: str = translations.get(post.cta.text.key, post.cta.text.key)
-            html_output.append(
-                textwrap.dedent(f"""\
-                    <div class="blog-item" id="{post.id if post.id else ""}">
-                        <h3>{title}</h3>
-                        <p>{excerpt}</p>
-                        <a href="{post.cta.uri}" class="read-more">{cta_text}</a>
-                    </div>
-                """)
-            )
-        return "\n".join(html_output)
+        template = self.jinja_env.get_template("blocks/blog.html")
+        return template.render(items=data, translations=translations)

--- a/build_protocols/interfaces.py
+++ b/build_protocols/interfaces.py
@@ -204,6 +204,7 @@ class PageBuilder(Protocol):
         main_content: str,
         header_content: Optional[str] = None,
         footer_content: Optional[str] = None,
+        page_title: Optional[str] = None,
     ) -> str:
         """Assembles a full HTML page using translated and generated content.
 

--- a/build_protocols/page_assembly.py
+++ b/build_protocols/page_assembly.py
@@ -115,4 +115,4 @@ class DefaultPageBuilder(PageBuilder):
         # Server-side translation of base.html structure can be done by passing translations
         # to its render context (as done above).
 
-        return base_template.render(context)
+        return str(base_template.render(context))

--- a/build_protocols/page_assembly.py
+++ b/build_protocols/page_assembly.py
@@ -7,11 +7,9 @@ main content, and language-specific attributes to form a complete HTML page.
 """
 
 import logging
-import re
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
-from bs4 import BeautifulSoup
-from bs4.element import Tag
+from jinja2 import Environment
 
 from .interfaces import PageBuilder, TranslationProvider, Translations
 
@@ -24,291 +22,97 @@ class PageAssemblyError(Exception):
 
 class DefaultPageBuilder(PageBuilder):
     """
-    Default implementation for assembling HTML pages.
+    Default implementation for assembling HTML pages using Jinja2.
 
-    This builder can extract parts from a base HTML file (like header, footer)
-    and then combine them with generated main content and translations to
-    produce the final HTML output for different languages.
+    This builder uses a Jinja2 environment to render a base template,
+    injecting main content, translations, and other necessary data.
     """
 
-    def __init__(self, translation_provider: TranslationProvider):
+    def __init__(
+        self, translation_provider: TranslationProvider, jinja_env: Environment
+    ):
         """Initializes the DefaultPageBuilder.
 
         Args:
             translation_provider: An instance of a TranslationProvider
-                                  to handle content translation.
+                                  to handle content translation (can be used by templates).
+            jinja_env: An initialized Jinja2 Environment.
         """
         self.translation_provider = translation_provider
-
-    def _get_attributes_string(self, tag: Tag) -> str:
-        """Converts a BeautifulSoup Tag's attributes into an HTML string.
-
-        Args:
-            tag: The BeautifulSoup Tag object.
-
-        Returns:
-            A string representing the tag's attributes (e.g., ' class="foo" id="bar"').
-        """
-        attrs_list = []
-        if tag.attrs:
-            for key, value in tag.attrs.items():
-                if isinstance(value, list):  # Handle multi-valued attributes like class
-                    value = " ".join(value)
-                attrs_list.append(f'{key}="{value}"')
-        return " ".join(attrs_list)
-
-    def _extract_doctype(self, base_content: str) -> str:
-        """Extracts the DOCTYPE declaration from the base HTML content.
-
-        Args:
-            base_content: The full string content of the base HTML file.
-
-        Returns:
-            The DOCTYPE string (e.g., "<!DOCTYPE html>\n") or an empty string
-            if not found.
-        """
-        doctype_match = re.match(
-            r"^(<!DOCTYPE[^>]+>)\s*", base_content, re.IGNORECASE | re.DOTALL
-        )
-        return doctype_match.group(1) + "\n" if doctype_match else ""
-
-    def _extract_header_footer_from_body(
-        self, body_tag: Optional[Tag]
-    ) -> Tuple[List[str], List[str]]:
-        """Extracts header and footer content parts relative to the <main> tag.
-
-        Args:
-            body_tag: The BeautifulSoup Tag object for the <body> element.
-
-        Returns:
-            A tuple containing two lists of strings: (header_parts, footer_parts).
-        """
-        header_content_parts: List[str] = []
-        footer_content_parts: List[str] = []
-
-        if not (body_tag and isinstance(body_tag, Tag)):
-            logger.warning("<body> tag not found. Header/footer content will be empty.")
-            return header_content_parts, footer_content_parts
-
-        main_tag = body_tag.find("main")
-        if not (main_tag and isinstance(main_tag, Tag)):
-            logger.warning(
-                "<main> tag not found. Header/footer content may be incomplete."
-            )
-            # If no <main>, consider all direct children of <body> as header for simplicity,
-            # or handle as an error, or return empty. For now, returning empty for footer.
-            # This part might need refinement based on expected template structures.
-            for element in body_tag.children:  # Iterate direct children
-                if str(element).strip():
-                    header_content_parts.append(str(element))
-            return header_content_parts, footer_content_parts
-
-        for element in main_tag.previous_siblings:
-            if str(element).strip():
-                header_content_parts.insert(
-                    0, str(element)
-                )  # Prepend to maintain order
-        for element in main_tag.find_next_siblings():
-            if str(element).strip():
-                footer_content_parts.append(str(element))
-
-        return header_content_parts, footer_content_parts
-
-    def _build_html_shell(
-        self, soup: BeautifulSoup, doctype_str: str
-    ) -> Tuple[str, str]:
-        """Builds the html_start and html_end strings.
-
-        Args:
-            soup: The BeautifulSoup object of the parsed base HTML.
-            doctype_str: The DOCTYPE string.
-
-        Returns:
-            A tuple (final_html_start, final_html_end).
-        """
-        html_tag_obj = soup.find("html")
-        html_start_str: str
-        html_end_str: str
-
-        if html_tag_obj and isinstance(html_tag_obj, Tag):
-            full_html_minus_doctype = str(html_tag_obj)
-            html_attrs_str = self._get_attributes_string(html_tag_obj)
-
-            head_tag = soup.head
-            head_content = str(head_tag) if head_tag else "<head></head>"
-
-            # Attempt to find existing <body> tag to split accurately
-            body_open_match = re.search(
-                r"<body[^>]*>", full_html_minus_doctype, re.IGNORECASE
-            )
-            if body_open_match:
-                # html_start includes <html>, <head>, and opening <body> tag
-                html_start_str = (
-                    f"<html {html_attrs_str}>{head_content}{body_open_match.group(0)}"
-                )
-            else:
-                # Fallback: if no <body> tag, construct a basic start
-                logger.warning(
-                    "No <body> tag found within <html>; constructing a basic one."
-                )
-                html_start_str = f"<html {html_attrs_str}>{head_content}<body>"
-
-            body_close_match = re.search(
-                r"</body>\s*</html>\s*$",
-                full_html_minus_doctype,
-                re.IGNORECASE | re.DOTALL,
-            )
-            html_end_str = (
-                body_close_match.group(0) if body_close_match else "</body></html>"
-            )
-        else:
-            logger.warning("<html> tag not found. Using default HTML structure.")
-            doctype_str = doctype_str or "<!DOCTYPE html>\n"
-            html_start_str = (
-                '<html><head><meta charset="UTF-8">'
-                '<meta name="viewport" content="width=device-width, '
-                'initial-scale=1.0"><title>Page</title></head><body>'
-            )
-            html_end_str = "\n</body>\n</html>"
-
-        final_html_start = doctype_str + html_start_str.strip() + "\n"
-        return final_html_start, html_end_str.strip()
+        self.jinja_env = jinja_env
 
     def extract_base_html_parts(
         self, base_html_path: str = "index.html"
     ) -> Tuple[str, str, str, str]:
-        """Extracts key structural parts from the base HTML file.
-
-        Returns a tuple: (html_start, header_content, footer_content, html_end).
-        - `html_start`: From <!DOCTYPE> up to and including the opening <body> tag.
-        - `header_content`: Content found between the <body> tag and the <main> tag.
-        - `footer_content`: Content found between the </main> tag and the </body> tag.
-        - `html_end`: Typically '</body></html>'.
-
-        Args:
-            base_html_path: Path to the base HTML template file.
-
-        Returns:
-            A tuple of four strings: (html_start, header_content, footer_content, html_end).
-
-        Raises:
-            PageAssemblyError: If the base_html_path file is not found.
         """
-        try:
-            with open(base_html_path, "r", encoding="utf-8") as f:
-                base_content = f.read()
-        except FileNotFoundError as e:
-            raise PageAssemblyError(
-                f"Base HTML file '{base_html_path}' not found."
-            ) from e
-
-        soup = BeautifulSoup(base_content, "html.parser")
-        doctype_str = self._extract_doctype(base_content)
-        final_html_start, final_html_end = self._build_html_shell(soup, doctype_str)
-        header_parts, footer_parts = self._extract_header_footer_from_body(soup.body)
-
-        return (
-            final_html_start,
-            "\n".join(header_parts),
-            "\n".join(footer_parts),
-            final_html_end,
+        Extracts key structural parts from the base HTML file.
+        NOTE: This method is now largely obsolete with Jinja2 managing the base structure.
+        It's kept to satisfy the protocol but should ideally be removed or re-evaluated
+        if the PageBuilder protocol changes. For now, it returns dummy values
+        as the main assembly logic is in `assemble_translated_page` using Jinja.
+        """
+        logger.warning(
+            "extract_base_html_parts is called but is largely obsolete "
+            "with Jinja2 templating. Returning dummy values."
         )
-
-    def _update_html_lang_attribute(self, html_start_str: str, lang: str) -> str:
-        """Updates or adds the lang attribute to the <html> tag."""
-        html_tag_pattern = re.compile(r"(<html[^>]*>)", re.IGNORECASE)
-        match = html_tag_pattern.search(html_start_str)
-
-        if not match:
-            logger.warning(
-                "No <html> tag found in html_start_str. Cannot set lang attribute."
-            )
-            # Fallback: if html_start_str is just doctype, append html tag
-            if html_start_str.lower().strip().startswith("<!doctype"):
-                return f'{html_start_str.strip()}\n<html lang="{lang}">'
-            return f'<html lang="{lang}">{html_start_str}'
-
-        original_html_tag = match.group(1)
-        new_html_tag: str
-
-        if re.search(r"lang\s*=", original_html_tag, re.IGNORECASE):
-            new_html_tag = re.sub(
-                r'(lang\s*=\s*["\'])([^"\']*)(["\'])',
-                rf"\1{lang}\3",
-                original_html_tag,
-                count=1,
-                flags=re.IGNORECASE,
-            )
-        else:
-            # Add lang attribute. Insert it after '<html'
-            new_html_tag = re.sub(
-                r"(<html)",
-                rf'\1 lang="{lang}"',
-                original_html_tag,
-                count=1,
-                flags=re.IGNORECASE,
-            )
-        return html_start_str.replace(original_html_tag, new_html_tag, 1)
+        # These parts are no longer extracted this way.
+        # The base.html Jinja template defines these sections.
+        # Returning placeholder values to satisfy the interface.
+        # The actual header/footer content for the template will be passed
+        # directly to assemble_translated_page or handled within base.html itself.
+        return ("", "", "", "")
 
     def assemble_translated_page(
         self,
         lang: str,
         translations: Translations,
-        html_parts: Tuple[str, str, str, str],
+        html_parts: Tuple[str, str, str, str], # This argument is now less relevant
         main_content: str,
-        header_content: Optional[str] = None,
-        footer_content: Optional[str] = None,
+        header_content: Optional[str] = None, # Can be passed to Jinja context
+        footer_content: Optional[str] = None, # Can be passed to Jinja context
+        page_title: Optional[str] = None, # Example of an additional context variable
     ) -> str:
-        """Assembles a full HTML page with translated content.
+        """Assembles a full HTML page using a Jinja2 base template.
 
         Args:
             lang: The language code (e.g., "en").
             translations: A dictionary of translations for the language.
-            html_parts: A tuple (html_start, header_original, footer_original, html_end)
-                        from `extract_base_html_parts`.
-            main_content: The HTML string for the main content of the page.
-            header_content: Optional pre-translated header HTML. If None,
-                            the original header from html_parts is used.
-            footer_content: Optional pre-translated footer HTML. If None,
-                            the original footer from html_parts is used.
+            html_parts: A tuple from `extract_base_html_parts`.
+                        NOTE: Largely ignored due to Jinja2 templating.
+            main_content: The HTML string for the main content of the page
+                          (already rendered blocks).
+            header_content: Optional HTML content for the header block in base.html.
+            footer_content: Optional HTML content for the footer block in base.html.
+            page_title: Optional title for the page.
+
         Returns:
             The complete HTML string for the translated page.
         """
-        html_start_original, header_original, footer_original, html_end_original = (
-            html_parts
-        )
+        base_template = self.jinja_env.get_template("base.html")
 
-        # Use provided header/footer if available, otherwise use originals from template
-        current_header_str = (
-            header_content if header_content is not None else header_original
-        )
-        current_footer_str = (
-            footer_content if footer_content is not None else footer_original
-        )
+        # Prepare context for the Jinja template
+        # The `base.html` template expects `lang`, `main_content`, etc.
+        # `translations` can also be passed if needed directly by the base template,
+        # though individual blocks should already be translated.
+        # `header_content` and `footer_content` can be passed to fill respective blocks
+        # in `base.html` if they are not hardcoded or built differently.
+        context = {
+            "lang": lang,
+            "title": page_title or translations.get("default_page_title", "Landing Page"),
+            "translations": translations, # Make translations available to base template
+            "main_content": main_content, # This is the aggregated HTML of all blocks
+            "header_content": header_content, # For {% block header_content %}
+            "footer_content": footer_content, # For {% block footer_content %}
+            # Add any other variables your base.html might need
+        }
 
-        # Translate the header and footer content (even if they were pre-translated,
-        # this ensures any remaining i18n tags are processed).
-        final_header_content = self.translation_provider.translate_html_content(
-            current_header_str, translations
-        )
-        final_footer_content = self.translation_provider.translate_html_content(
-            current_footer_str, translations
-        )
+        # The translation_provider might still be useful if base.html itself has i18n tags
+        # that were not part of the pre-rendered header/footer content.
+        # However, if header/footer content are passed as pre-rendered strings,
+        # they should already be translated. The main_content is also pre-rendered.
+        # For now, we assume base.html primarily structures these parts.
+        # If base.html has its own `data-i18n` tags, they'd be handled by client-side JS.
+        # Server-side translation of base.html structure can be done by passing translations
+        # to its render context (as done above).
 
-        # Set the lang attribute on the <html> tag.
-        final_html_start = self._update_html_lang_attribute(html_start_original, lang)
-
-        # Assemble the full page.
-        # Ensure <main> tags correctly wrap the main_content.
-        page_components = [
-            final_html_start,
-            final_header_content,
-            "\n<main>\n",  # Ensure main tag is present
-            main_content,
-            "\n</main>\n",  # Ensure main tag is closed
-            final_footer_content,
-            html_end_original,
-        ]
-        return "".join(
-            filter(None, page_components)
-        )  # Filter out None or empty strings
+        return base_template.render(context)

--- a/index.html
+++ b/index.html
@@ -1,7 +1,9 @@
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+
     <meta
       content="A simple and modern landing page template for showcasing your business, services, or portfolio."
       name="description"
@@ -10,6 +12,7 @@
       content="landing page, template, HTML, CSS, JavaScript, responsive, business, portfolio, services"
       name="keywords"
     />
+
     <title>Simple Landing Page</title>
     <link href="public/style.css" rel="stylesheet" />
   </head>
@@ -30,7 +33,7 @@
         </button>
         <div class="nav-items">
           <ul>
-            <!-- Navigation items will be dynamically injected here -->
+            <!-- Navigation items will be dynamically injected here by client-side JS -->
           </ul>
           <button aria-label="Switch to Dark Mode" id="dark-mode-toggle">
             🌙
@@ -42,56 +45,56 @@
         </div>
       </nav>
     </header>
+
     <main>
       <section class="hero">
         <h1>hero_title_v1</h1>
         <p>hero_subtitle_v1</p>
-        <a class="cta-button" href="#signup">hero_cta_v1</a>
+        <a href="#signup" class="cta-button">hero_cta_v1</a>
         <!-- Selected variation: hero_v1 -->
       </section>
-
       <section
         class="features"
+        id="features"
         data-aos="fade-up"
         data-aos-delay="100"
-        id="features"
       >
         <h2 data-i18n="features_title">Our Features</h2>
         <div class="feature-list">
-          <!-- Feature items will be dynamically injected here by build.py -->
           <div class="feature-item">
             <h3>Feature One</h3>
             <p>Description of feature one.</p>
           </div>
+
           <div class="feature-item">
             <h3>Feature Two</h3>
             <p>Description of feature two.</p>
           </div>
+
           <div class="feature-item">
             <h3>Feature Three</h3>
             <p>Description of feature three.</p>
           </div>
         </div>
       </section>
-
       <section class="testimonials" id="testimonials">
         <h2 data-i18n="testimonials_title">What Our Users Say</h2>
         <div class="testimonial-list">
-          <!-- Testimonial items will be dynamically injected here by build.py -->
           <div class="testimonial-item">
             <img
-              alt="User 1 Photo"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODAiIGhlaWdodD0iODAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHJlY3Qgd2lkdGg9IjgwIiBoZWlnaHQ9IjgwIiBmaWxsPSIjY2NjIi8+PC9zdmc+"
+              alt="User 1 Photo"
             />
             <p>
               "This is the best service I have ever used. Highly recommended!"
             </p>
             <h4>- Jane Doe</h4>
           </div>
+
           <div class="testimonial-item">
             <img
-              alt="User 2 Photo"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODAiIGhlaWdodD0iODAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHJlY3Qgd2lkdGg9IjgwIiBoZWlnaHQ9IjgwIiBmaWxsPSIjY2NjIi8+PC9zdmc+"
+              alt="User 2 Photo"
             />
             <p>
               "Amazing features and incredible support. My business has grown
@@ -99,10 +102,11 @@
             </p>
             <h4>- John Smith</h4>
           </div>
+
           <div class="testimonial-item">
             <img
-              alt="User 3 Photo"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODAiIGhlaWdodD0iODAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHJlY3Qgd2lkdGg9IjgwIiBoZWlnaHQ9IjgwIiBmaWxsPSIjY2NjIi8+PC9zdmc+"
+              alt="User 3 Photo"
             />
             <p>
               "A game-changer for our workflow. Simple, effective, and
@@ -112,73 +116,76 @@
           </div>
         </div>
       </section>
-
       <section class="portfolio" id="portfolio">
         <h2 data-i18n="portfolio_title">Our Work</h2>
         <div class="portfolio-grid">
-          <!-- Portfolio items will be dynamically injected here by build.py -->
           <div class="portfolio-item" id="project1">
             <img
-              alt="Portfolio image"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg=="
+              alt="Portfolio image"
             />
             <h3>Project Alpha</h3>
             <p>Description for Project Alpha.</p>
           </div>
+
           <div class="portfolio-item" id="project2">
             <img
-              alt="Portfolio image"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg=="
+              alt="Portfolio image"
             />
             <h3>Project Beta</h3>
             <p>Description for Project Beta.</p>
           </div>
+
           <div class="portfolio-item" id="project3">
             <img
-              alt="Portfolio image"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg=="
+              alt="Portfolio image"
             />
             <h3>Project Gamma</h3>
             <p>Description for Project Gamma.</p>
           </div>
+
           <div class="portfolio-item" id="project4">
             <img
-              alt="Portfolio image"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg=="
+              alt="Portfolio image"
             />
             <h3>Project Delta</h3>
             <p>Description for Project Delta.</p>
           </div>
         </div>
       </section>
-
       <section class="blog" id="blog">
         <h2 data-i18n="blog_title">Latest Posts</h2>
         <div class="blog-list">
-          <!-- Blog posts will be dynamically injected here by build.py -->
           <div class="blog-item" id="post1">
             <h3>Alpha Post Title</h3>
             <p>Excerpt for Alpha blog post...</p>
-            <a class="read-more" href="#post1-link">Read Alpha Post</a>
+            <a href="#post1-link" class="read-more">Read Alpha Post</a>
           </div>
+
           <div class="blog-item" id="post2">
             <h3>Beta Post Title</h3>
             <p>Excerpt for Beta blog post...</p>
-            <a class="read-more" href="#post2-link">Read Beta Post</a>
+            <a href="#post2-link" class="read-more">Read Beta Post</a>
           </div>
+
           <div class="blog-item" id="post3">
             <h3>Gamma Post Title</h3>
             <p>Excerpt for Gamma blog post...</p>
-            <a class="read-more" href="#post3-link">Read Gamma Post</a>
+            <a href="#post3-link" class="read-more">Read Gamma Post</a>
           </div>
         </div>
       </section>
     </main>
+
     <footer>
       <p data-i18n="footer_text">
         &amp;copy; 2023 Simple Landing Page. All rights reserved.
       </p>
     </footer>
+
     <script>
       // Dark Mode Toggle
       const darkModeToggle = document.getElementById("dark-mode-toggle");
@@ -186,12 +193,6 @@
       let currentTranslations = {};
 
       async function generateNavigation() {
-        // Determine the current language to fetch the correct config file.
-        // The `initializeApp` function sets `preferredLang` and calls `setLanguage`,
-        // which in turn updates `document.documentElement.lang`.
-        // We should ensure this function is called after language is determined,
-        // or pass lang to it.
-        // For simplicity, let's assume `document.documentElement.lang` is set or defaults correctly.
         const currentLang = document.documentElement.lang || "en";
         const configPath = `public/generated_configs/config_${currentLang}.json`;
 
@@ -199,45 +200,10 @@
           const response = await fetch(configPath);
           if (!response.ok) {
             console.error(`Failed to load ${configPath}:`, response.statusText);
-            // Fallback to default config if language specific one fails? Or just error out?
-            // For now, let's try the default base config as a fallback.
-            const fallbackResponse = await fetch("public/config.json");
-            if (!fallbackResponse.ok) {
-              console.error(
-                "Failed to load fallback public/config.json:",
-                fallbackResponse.statusText
-              );
-              return;
-            }
-            const config = await fallbackResponse.json();
-            // Check if fallback has navigation, probably not in the desired processed format.
-            // This fallback might not be ideal if the structure is different.
-            // Best to ensure build.py always creates these files.
-            console.warn(
-              `Falling back to public/config.json for navigation due to error with ${configPath}. Navigation might be incomplete or unstyled.`
-            );
-            const navItems = config.navigation; // This might be undefined or not what we expect
-            if (!navItems) {
-              console.error(
-                "Navigation data not found in fallback config.json."
-              );
-              return;
-            }
-            // Process fallback navItems if necessary (they won't have translated labels directly)
-            // This part needs careful consideration if we want a robust fallback.
-            // For now, the primary path is to load the generated config.
-            // The existing code below expects `item.label_i18n_key` and uses it for `data-i18n`.
-            // The generated config from build.py already includes a 'label' field with the translated text.
-            // So, if we successfully load `configPath`, the `item.label` should be used.
-            // If we fallback, and `config.navigation` is raw (only i18n keys), it will still mostly work
-            // as `applyTranslations` will translate it later.
-
-            // Let's simplify: if the specific config fails, we log error and return.
-            // The build process should guarantee these files.
             return;
           }
           const config = await response.json();
-          const navItems = config.navigation; // This should now have translated labels if loaded from generated_configs
+          const navItems = config.navigation;
 
           if (navItems && Array.isArray(navItems)) {
             const navUl = document.querySelector(".nav-items ul");
@@ -245,33 +211,19 @@
               console.error("Navigation <ul> element not found.");
               return;
             }
-            navUl.innerHTML = ""; // Clear existing items
+            navUl.innerHTML = "";
 
             navItems.forEach((item) => {
               const li = document.createElement("li");
               const a = document.createElement("a");
-              // The generated config now has a 'label' field with the translated text.
-              // And 'label_i18n_key' for potential future use or if applyTranslations needs it.
-              // We should use the pre-translated label directly.
-              // If applyTranslations is still desired to run over these, it needs to be aware.
-              // For now, let's use the translated label from the config.
-              a.textContent = item.label; // Use the translated label
+              a.textContent = item.label;
               a.href = item.href;
-              // Optionally, keep data-i18n if other mechanisms rely on it,
-              // or if we want applyTranslations to re-translate if language changes *after* nav generation.
-              // Given generateNavigation is called in initializeApp before setLanguage,
-              // and setLanguage calls applyTranslations, it's good to keep data-i18n.
-              // The `build.py` now adds `label_i18n_key` to the generated config.
               if (item.label_i18n_key) {
                 a.setAttribute("data-i18n", item.label_i18n_key);
               }
               li.appendChild(a);
               navUl.appendChild(li);
             });
-            // Since navigation is generated before initial applyTranslations,
-            // and the labels in generated_config are already translated for that language,
-            // we might not need to explicitly call applyTranslations here for nav items.
-            // However, if the language changes later, applyTranslations will handle it.
           }
         } catch (error) {
           console.error("Error generating navigation:", error);
@@ -300,24 +252,22 @@
         document.querySelectorAll("[data-i18n]").forEach((element) => {
           const key = element.getAttribute("data-i18n");
           if (translations[key] && element.id !== "dark-mode-toggle") {
-            // Don't translate the icon button
             element.textContent = translations[key];
           }
         });
-        // Update dark mode toggle icon and aria-label based on current language and mode
         updateDarkModeButtonIcon();
       }
 
       function updateDarkModeButtonIcon() {
         const isDarkMode = body.classList.contains("dark-mode");
         if (isDarkMode) {
-          darkModeToggle.textContent = "☀️"; // Sun icon for switching to light mode
+          darkModeToggle.textContent = "☀️";
           darkModeToggle.setAttribute(
             "aria-label",
             currentTranslations["light_mode_toggle"] || "Switch to Light Mode"
           );
         } else {
-          darkModeToggle.textContent = "🌙"; // Moon icon for switching to dark mode
+          darkModeToggle.textContent = "🌙";
           darkModeToggle.setAttribute(
             "aria-label",
             currentTranslations["dark_mode_toggle"] || "Switch to Dark Mode"
@@ -330,9 +280,8 @@
         if (translations) {
           applyTranslations(translations);
           localStorage.setItem("language", lang);
-          document.documentElement.lang = lang; // Update the lang attribute of the html tag
+          document.documentElement.lang = lang;
 
-          // Update active class on buttons
           document
             .querySelectorAll("#language-switcher button")
             .forEach((btn) => {
@@ -344,10 +293,8 @@
         }
       }
 
-      // Dark Mode Toggle
       if (localStorage.getItem("darkMode") === "enabled") {
         body.classList.add("dark-mode");
-        // Text will be set after translations load
       }
 
       darkModeToggle.addEventListener("click", () => {
@@ -357,10 +304,9 @@
         } else {
           localStorage.setItem("darkMode", "disabled");
         }
-        updateDarkModeButtonIcon(); // Update button icon and aria-label on toggle
+        updateDarkModeButtonIcon();
       });
 
-      // Language Switcher
       const languageSwitcher = document.getElementById("language-switcher");
       if (languageSwitcher) {
         languageSwitcher.addEventListener("click", (event) => {
@@ -372,37 +318,27 @@
         });
       }
 
-      // Initial setup
       async function initializeApp() {
-        // Language must be determined first, so generateNavigation can use it.
         const preferredLang = localStorage.getItem("language") || "en";
-        // Set document.documentElement.lang here, so generateNavigation can pick it up.
-        // setLanguage also does this, but generateNavigation might be called before setLanguage completes fully if not careful.
         document.documentElement.lang = preferredLang;
 
-        await generateNavigation(); // Generate navigation (now uses document.documentElement.lang)
-        await setLanguage(preferredLang); // Then set language (which applies all other translations)
-
-        // No need to initialize the old theme switcher here
-        // The dark mode toggle is already initialized by checking localStorage for 'darkMode'
-        // and its button text/icon will be set by updateDarkModeButtonText() called within setLanguage -> applyTranslations.
+        await generateNavigation();
+        await setLanguage(preferredLang);
       }
 
       initializeApp();
 
-      // Hamburger Menu Toggle
       const hamburgerMenu = document.querySelector(".hamburger-menu");
-      const navItems = document.querySelector(".nav-items");
+      const navItemsContainer = document.querySelector(".nav-items");
 
-      if (hamburgerMenu && navItems) {
+      if (hamburgerMenu && navItemsContainer) {
         hamburgerMenu.addEventListener("click", () => {
-          navItems.classList.toggle("active");
-          const isExpanded = navItems.classList.contains("active");
+          navItemsContainer.classList.toggle("active");
+          const isExpanded = navItemsContainer.classList.contains("active");
           hamburgerMenu.setAttribute("aria-expanded", isExpanded);
         });
       }
 
-      // Contact Form Validation
       const contactForm = document.querySelector(".contact-form form");
       if (contactForm) {
         contactForm.addEventListener("submit", function (event) {
@@ -415,14 +351,12 @@
           if (name === "") {
             isValid = false;
             errors.push("Name is required.");
-            // You could add error display logic here, e.g., document.getElementById('name-error').textContent = "Name is required.";
           }
 
           if (email === "") {
             isValid = false;
             errors.push("Email is required.");
           } else {
-            // Basic email format validation
             const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
             if (!emailPattern.test(email)) {
               isValid = false;
@@ -436,13 +370,11 @@
           }
 
           if (!isValid) {
-            event.preventDefault(); // Prevent form submission
+            event.preventDefault();
             alert(
               "Please correct the following errors:\n\n" + errors.join("\n")
             );
-            // For a better UX, display errors next to fields or in a dedicated error message area
           }
-          // If isValid is true, the form will submit to Formspree
         });
       }
     </script>

--- a/index_es.html
+++ b/index_es.html
@@ -1,7 +1,9 @@
+<!doctype html>
 <html lang="es">
   <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+
     <meta
       content="A simple and modern landing page template for showcasing your business, services, or portfolio."
       name="description"
@@ -10,6 +12,7 @@
       content="landing page, template, HTML, CSS, JavaScript, responsive, business, portfolio, services"
       name="keywords"
     />
+
     <title>Simple Landing Page</title>
     <link href="public/style.css" rel="stylesheet" />
   </head>
@@ -30,7 +33,7 @@
         </button>
         <div class="nav-items">
           <ul>
-            <!-- Navigation items will be dynamically injected here -->
+            <!-- Navigation items will be dynamically injected here by client-side JS -->
           </ul>
           <button aria-label="Switch to Dark Mode" id="dark-mode-toggle">
             🌙
@@ -42,54 +45,54 @@
         </div>
       </nav>
     </header>
+
     <main>
       <section class="hero">
         <h1>hero_title_v1</h1>
         <p>hero_subtitle_v1</p>
-        <a class="cta-button" href="#signup">hero_cta_v1</a>
+        <a href="#signup" class="cta-button">hero_cta_v1</a>
         <!-- Selected variation: hero_v1 -->
       </section>
-
       <section
         class="features"
+        id="features"
         data-aos="fade-up"
         data-aos-delay="100"
-        id="features"
       >
         <h2 data-i18n="features_title">Nuestras Características</h2>
         <div class="feature-list">
-          <!-- Feature items will be dynamically injected here by build.py -->
           <div class="feature-item">
             <h3>Característica Uno</h3>
             <p>Descripción de la característica uno.</p>
           </div>
+
           <div class="feature-item">
             <h3>Característica Dos</h3>
             <p>Descripción de la característica dos.</p>
           </div>
+
           <div class="feature-item">
             <h3>Característica Tres</h3>
             <p>Descripción of la característica tres.</p>
           </div>
         </div>
       </section>
-
       <section class="testimonials" id="testimonials">
         <h2 data-i18n="testimonials_title">Lo Que Dicen Nuestros Usuarios</h2>
         <div class="testimonial-list">
-          <!-- Testimonial items will be dynamically injected here by build.py -->
           <div class="testimonial-item">
             <img
-              alt="Foto del Usuario 1"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODAiIGhlaWdodD0iODAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHJlY3Qgd2lkdGg9IjgwIiBoZWlnaHQ9IjgwIiBmaWxsPSIjY2NjIi8+PC9zdmc+"
+              alt="Foto del Usuario 1"
             />
             <p>"Este es el mejor servicio que he usado. ¡Muy recomendado!"</p>
             <h4>- Jane Doe</h4>
           </div>
+
           <div class="testimonial-item">
             <img
-              alt="Foto del Usuario 2"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODAiIGhlaWdodD0iODAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHJlY3Qgd2lkdGg9IjgwIiBoZWlnaHQ9IjgwIiBmaWxsPSIjY2NjIi8+PC9zdmc+"
+              alt="Foto del Usuario 2"
             />
             <p>
               "Características increíbles y un soporte espectacular. Mi negocio
@@ -97,10 +100,11 @@
             </p>
             <h4>- John Smith</h4>
           </div>
+
           <div class="testimonial-item">
             <img
-              alt="Foto del Usuario 3"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODAiIGhlaWdodD0iODAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHJlY3Qgd2lkdGg9IjgwIiBoZWlnaHQ9IjgwIiBmaWxsPSIjY2NjIi8+PC9zdmc+"
+              alt="Foto del Usuario 3"
             />
             <p>
               "Un cambio de juego para nuestro flujo de trabajo. Simple,
@@ -110,73 +114,76 @@
           </div>
         </div>
       </section>
-
       <section class="portfolio" id="portfolio">
         <h2 data-i18n="portfolio_title">Nuestro Trabajo</h2>
         <div class="portfolio-grid">
-          <!-- Portfolio items will be dynamically injected here by build.py -->
           <div class="portfolio-item" id="project1">
             <img
-              alt="Portfolio image"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg=="
+              alt="Portfolio image"
             />
             <h3>Proyecto Alfa</h3>
             <p>Descripción del Proyecto Alfa.</p>
           </div>
+
           <div class="portfolio-item" id="project2">
             <img
-              alt="Portfolio image"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg=="
+              alt="Portfolio image"
             />
             <h3>Proyecto Beta</h3>
             <p>Descripción del Proyecto Beta.</p>
           </div>
+
           <div class="portfolio-item" id="project3">
             <img
-              alt="Portfolio image"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg=="
+              alt="Portfolio image"
             />
             <h3>Proyecto Gama</h3>
             <p>Descripción del Proyecto Gama.</p>
           </div>
+
           <div class="portfolio-item" id="project4">
             <img
-              alt="Portfolio image"
               src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMzAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg=="
+              alt="Portfolio image"
             />
             <h3>Proyecto Delta</h3>
             <p>Descripción del Proyecto Delta.</p>
           </div>
         </div>
       </section>
-
       <section class="blog" id="blog">
         <h2 data-i18n="blog_title">Últimas Publicaciones</h2>
         <div class="blog-list">
-          <!-- Blog posts will be dynamically injected here by build.py -->
           <div class="blog-item" id="post1">
             <h3>Título de la Publicación Alfa</h3>
             <p>Extracto de la publicación Alfa del blog...</p>
-            <a class="read-more" href="#post1-link">Leer Publicación Alfa</a>
+            <a href="#post1-link" class="read-more">Leer Publicación Alfa</a>
           </div>
+
           <div class="blog-item" id="post2">
             <h3>Título de la Publicación Beta</h3>
             <p>Extracto de la publicación Beta del blog...</p>
-            <a class="read-more" href="#post2-link">Leer Publicación Beta</a>
+            <a href="#post2-link" class="read-more">Leer Publicación Beta</a>
           </div>
+
           <div class="blog-item" id="post3">
             <h3>Título de la Publicación Gama</h3>
             <p>Extracto de la publicación Gama del blog...</p>
-            <a class="read-more" href="#post3-link">Leer Publicación Gama</a>
+            <a href="#post3-link" class="read-more">Leer Publicación Gama</a>
           </div>
         </div>
       </section>
     </main>
+
     <footer>
       <p data-i18n="footer_text">
-        &amp;copy; 2023 Página de Destino Simple. Todos los derechos reservados.
+        &amp;copy; 2023 Simple Landing Page. All rights reserved.
       </p>
     </footer>
+
     <script>
       // Dark Mode Toggle
       const darkModeToggle = document.getElementById("dark-mode-toggle");
@@ -184,12 +191,6 @@
       let currentTranslations = {};
 
       async function generateNavigation() {
-        // Determine the current language to fetch the correct config file.
-        // The `initializeApp` function sets `preferredLang` and calls `setLanguage`,
-        // which in turn updates `document.documentElement.lang`.
-        // We should ensure this function is called after language is determined,
-        // or pass lang to it.
-        // For simplicity, let's assume `document.documentElement.lang` is set or defaults correctly.
         const currentLang = document.documentElement.lang || "en";
         const configPath = `public/generated_configs/config_${currentLang}.json`;
 
@@ -197,45 +198,10 @@
           const response = await fetch(configPath);
           if (!response.ok) {
             console.error(`Failed to load ${configPath}:`, response.statusText);
-            // Fallback to default config if language specific one fails? Or just error out?
-            // For now, let's try the default base config as a fallback.
-            const fallbackResponse = await fetch("public/config.json");
-            if (!fallbackResponse.ok) {
-              console.error(
-                "Failed to load fallback public/config.json:",
-                fallbackResponse.statusText
-              );
-              return;
-            }
-            const config = await fallbackResponse.json();
-            // Check if fallback has navigation, probably not in the desired processed format.
-            // This fallback might not be ideal if the structure is different.
-            // Best to ensure build.py always creates these files.
-            console.warn(
-              `Falling back to public/config.json for navigation due to error with ${configPath}. Navigation might be incomplete or unstyled.`
-            );
-            const navItems = config.navigation; // This might be undefined or not what we expect
-            if (!navItems) {
-              console.error(
-                "Navigation data not found in fallback config.json."
-              );
-              return;
-            }
-            // Process fallback navItems if necessary (they won't have translated labels directly)
-            // This part needs careful consideration if we want a robust fallback.
-            // For now, the primary path is to load the generated config.
-            // The existing code below expects `item.label_i18n_key` and uses it for `data-i18n`.
-            // The generated config from build.py already includes a 'label' field with the translated text.
-            // So, if we successfully load `configPath`, the `item.label` should be used.
-            // If we fallback, and `config.navigation` is raw (only i18n keys), it will still mostly work
-            // as `applyTranslations` will translate it later.
-
-            // Let's simplify: if the specific config fails, we log error and return.
-            // The build process should guarantee these files.
             return;
           }
           const config = await response.json();
-          const navItems = config.navigation; // This should now have translated labels if loaded from generated_configs
+          const navItems = config.navigation;
 
           if (navItems && Array.isArray(navItems)) {
             const navUl = document.querySelector(".nav-items ul");
@@ -243,33 +209,19 @@
               console.error("Navigation <ul> element not found.");
               return;
             }
-            navUl.innerHTML = ""; // Clear existing items
+            navUl.innerHTML = "";
 
             navItems.forEach((item) => {
               const li = document.createElement("li");
               const a = document.createElement("a");
-              // The generated config now has a 'label' field with the translated text.
-              // And 'label_i18n_key' for potential future use or if applyTranslations needs it.
-              // We should use the pre-translated label directly.
-              // If applyTranslations is still desired to run over these, it needs to be aware.
-              // For now, let's use the translated label from the config.
-              a.textContent = item.label; // Use the translated label
+              a.textContent = item.label;
               a.href = item.href;
-              // Optionally, keep data-i18n if other mechanisms rely on it,
-              // or if we want applyTranslations to re-translate if language changes *after* nav generation.
-              // Given generateNavigation is called in initializeApp before setLanguage,
-              // and setLanguage calls applyTranslations, it's good to keep data-i18n.
-              // The `build.py` now adds `label_i18n_key` to the generated config.
               if (item.label_i18n_key) {
                 a.setAttribute("data-i18n", item.label_i18n_key);
               }
               li.appendChild(a);
               navUl.appendChild(li);
             });
-            // Since navigation is generated before initial applyTranslations,
-            // and the labels in generated_config are already translated for that language,
-            // we might not need to explicitly call applyTranslations here for nav items.
-            // However, if the language changes later, applyTranslations will handle it.
           }
         } catch (error) {
           console.error("Error generating navigation:", error);
@@ -298,24 +250,22 @@
         document.querySelectorAll("[data-i18n]").forEach((element) => {
           const key = element.getAttribute("data-i18n");
           if (translations[key] && element.id !== "dark-mode-toggle") {
-            // Don't translate the icon button
             element.textContent = translations[key];
           }
         });
-        // Update dark mode toggle icon and aria-label based on current language and mode
         updateDarkModeButtonIcon();
       }
 
       function updateDarkModeButtonIcon() {
         const isDarkMode = body.classList.contains("dark-mode");
         if (isDarkMode) {
-          darkModeToggle.textContent = "☀️"; // Sun icon for switching to light mode
+          darkModeToggle.textContent = "☀️";
           darkModeToggle.setAttribute(
             "aria-label",
             currentTranslations["light_mode_toggle"] || "Switch to Light Mode"
           );
         } else {
-          darkModeToggle.textContent = "🌙"; // Moon icon for switching to dark mode
+          darkModeToggle.textContent = "🌙";
           darkModeToggle.setAttribute(
             "aria-label",
             currentTranslations["dark_mode_toggle"] || "Switch to Dark Mode"
@@ -328,9 +278,8 @@
         if (translations) {
           applyTranslations(translations);
           localStorage.setItem("language", lang);
-          document.documentElement.lang = lang; // Update the lang attribute of the html tag
+          document.documentElement.lang = lang;
 
-          // Update active class on buttons
           document
             .querySelectorAll("#language-switcher button")
             .forEach((btn) => {
@@ -342,10 +291,8 @@
         }
       }
 
-      // Dark Mode Toggle
       if (localStorage.getItem("darkMode") === "enabled") {
         body.classList.add("dark-mode");
-        // Text will be set after translations load
       }
 
       darkModeToggle.addEventListener("click", () => {
@@ -355,10 +302,9 @@
         } else {
           localStorage.setItem("darkMode", "disabled");
         }
-        updateDarkModeButtonIcon(); // Update button icon and aria-label on toggle
+        updateDarkModeButtonIcon();
       });
 
-      // Language Switcher
       const languageSwitcher = document.getElementById("language-switcher");
       if (languageSwitcher) {
         languageSwitcher.addEventListener("click", (event) => {
@@ -370,37 +316,27 @@
         });
       }
 
-      // Initial setup
       async function initializeApp() {
-        // Language must be determined first, so generateNavigation can use it.
         const preferredLang = localStorage.getItem("language") || "en";
-        // Set document.documentElement.lang here, so generateNavigation can pick it up.
-        // setLanguage also does this, but generateNavigation might be called before setLanguage completes fully if not careful.
         document.documentElement.lang = preferredLang;
 
-        await generateNavigation(); // Generate navigation (now uses document.documentElement.lang)
-        await setLanguage(preferredLang); // Then set language (which applies all other translations)
-
-        // No need to initialize the old theme switcher here
-        // The dark mode toggle is already initialized by checking localStorage for 'darkMode'
-        // and its button text/icon will be set by updateDarkModeButtonText() called within setLanguage -> applyTranslations.
+        await generateNavigation();
+        await setLanguage(preferredLang);
       }
 
       initializeApp();
 
-      // Hamburger Menu Toggle
       const hamburgerMenu = document.querySelector(".hamburger-menu");
-      const navItems = document.querySelector(".nav-items");
+      const navItemsContainer = document.querySelector(".nav-items");
 
-      if (hamburgerMenu && navItems) {
+      if (hamburgerMenu && navItemsContainer) {
         hamburgerMenu.addEventListener("click", () => {
-          navItems.classList.toggle("active");
-          const isExpanded = navItems.classList.contains("active");
+          navItemsContainer.classList.toggle("active");
+          const isExpanded = navItemsContainer.classList.contains("active");
           hamburgerMenu.setAttribute("aria-expanded", isExpanded);
         });
       }
 
-      // Contact Form Validation
       const contactForm = document.querySelector(".contact-form form");
       if (contactForm) {
         contactForm.addEventListener("submit", function (event) {
@@ -413,14 +349,12 @@
           if (name === "") {
             isValid = false;
             errors.push("Name is required.");
-            // You could add error display logic here, e.g., document.getElementById('name-error').textContent = "Name is required.";
           }
 
           if (email === "") {
             isValid = false;
             errors.push("Email is required.");
           } else {
-            // Basic email format validation
             const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
             if (!emailPattern.test(email)) {
               isValid = false;
@@ -434,13 +368,11 @@
           }
 
           if (!isValid) {
-            event.preventDefault(); // Prevent form submission
+            event.preventDefault();
             alert(
               "Please correct the following errors:\n\n" + errors.join("\n")
             );
-            // For a better UX, display errors next to fields or in a dedicated error message area
           }
-          // If isValid is true, the form will submit to Formspree
         });
       }
     </script>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "grpcio",
     "grpcio-tools",
     "protobuf",
+    "Jinja2>=3.0.0",
 ]
 
 [tool.ruff.lint]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4>=4.13.4
 grpcio
 grpcio-tools
 protobuf
+Jinja2>=3.0.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="{{ lang | default('en') }}">
-<head>
+  <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
     {% block head_meta %}
@@ -16,8 +16,8 @@
     <title>{{ title | default('Simple Landing Page') }}</title>
     <link href="public/style.css" rel="stylesheet" />
     {% block head_extra %}{% endblock head_extra %}
-</head>
-<body>
+  </head>
+  <body>
     {% block header_content %}
     <header>
       <nav>
@@ -49,9 +49,7 @@
     </header>
     {% endblock header_content %}
 
-    <main>
-        {{ main_content | safe }}
-    </main>
+    <main>{{ main_content | safe }}</main>
 
     {% block footer_content %}
     <footer>
@@ -59,9 +57,7 @@
         &amp;copy; 2023 Simple Landing Page. All rights reserved.
       </p>
     </footer>
-    {% endblock footer_content %}
-
-    {% block scripts %}
+    {% endblock footer_content %} {% block scripts %}
     <script>
       // Dark Mode Toggle
       const darkModeToggle = document.getElementById("dark-mode-toggle");
@@ -255,5 +251,5 @@
       }
     </script>
     {% endblock scripts %}
-</body>
+  </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="{{ lang | default('en') }}">
+<head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    {% block head_meta %}
+    <meta
+      content="A simple and modern landing page template for showcasing your business, services, or portfolio."
+      name="description"
+    />
+    <meta
+      content="landing page, template, HTML, CSS, JavaScript, responsive, business, portfolio, services"
+      name="keywords"
+    />
+    {% endblock head_meta %}
+    <title>{{ title | default('Simple Landing Page') }}</title>
+    <link href="public/style.css" rel="stylesheet" />
+    {% block head_extra %}{% endblock head_extra %}
+</head>
+<body>
+    {% block header_content %}
+    <header>
+      <nav>
+        <div class="logo">
+          <a href="#">Logo</a>
+        </div>
+        <button
+          aria-expanded="false"
+          aria-label="Toggle menu"
+          class="hamburger-menu"
+        >
+          <span class="hamburger-bar"></span>
+          <span class="hamburger-bar"></span>
+          <span class="hamburger-bar"></span>
+        </button>
+        <div class="nav-items">
+          <ul>
+            <!-- Navigation items will be dynamically injected here by client-side JS -->
+          </ul>
+          <button aria-label="Switch to Dark Mode" id="dark-mode-toggle">
+            🌙
+          </button>
+          <div id="language-switcher">
+            <button data-lang="en">EN</button>
+            <button data-lang="es">ES</button>
+          </div>
+        </div>
+      </nav>
+    </header>
+    {% endblock header_content %}
+
+    <main>
+        {{ main_content | safe }}
+    </main>
+
+    {% block footer_content %}
+    <footer>
+      <p data-i18n="footer_text">
+        &amp;copy; 2023 Simple Landing Page. All rights reserved.
+      </p>
+    </footer>
+    {% endblock footer_content %}
+
+    {% block scripts %}
+    <script>
+      // Dark Mode Toggle
+      const darkModeToggle = document.getElementById("dark-mode-toggle");
+      const body = document.body;
+      let currentTranslations = {};
+
+      async function generateNavigation() {
+        const currentLang = document.documentElement.lang || "en";
+        const configPath = `public/generated_configs/config_${currentLang}.json`;
+
+        try {
+          const response = await fetch(configPath);
+          if (!response.ok) {
+            console.error(`Failed to load ${configPath}:`, response.statusText);
+            return;
+          }
+          const config = await response.json();
+          const navItems = config.navigation;
+
+          if (navItems && Array.isArray(navItems)) {
+            const navUl = document.querySelector(".nav-items ul");
+            if (!navUl) {
+              console.error("Navigation <ul> element not found.");
+              return;
+            }
+            navUl.innerHTML = "";
+
+            navItems.forEach((item) => {
+              const li = document.createElement("li");
+              const a = document.createElement("a");
+              a.textContent = item.label;
+              a.href = item.href;
+              if (item.label_i18n_key) {
+                a.setAttribute("data-i18n", item.label_i18n_key);
+              }
+              li.appendChild(a);
+              navUl.appendChild(li);
+            });
+          }
+        } catch (error) {
+          console.error("Error generating navigation:", error);
+        }
+      }
+
+      async function fetchTranslations(lang) {
+        try {
+          const response = await fetch(`public/locales/${lang}.json`);
+          if (!response.ok) {
+            console.error(
+              `Could not load ${lang}.json: ${response.statusText}`
+            );
+            return null;
+          }
+          return await response.json();
+        } catch (error) {
+          console.error(`Error fetching ${lang}.json:`, error);
+          return null;
+        }
+      }
+
+      function applyTranslations(translations) {
+        if (!translations) return;
+        currentTranslations = translations;
+        document.querySelectorAll("[data-i18n]").forEach((element) => {
+          const key = element.getAttribute("data-i18n");
+          if (translations[key] && element.id !== "dark-mode-toggle") {
+            element.textContent = translations[key];
+          }
+        });
+        updateDarkModeButtonIcon();
+      }
+
+      function updateDarkModeButtonIcon() {
+        const isDarkMode = body.classList.contains("dark-mode");
+        if (isDarkMode) {
+          darkModeToggle.textContent = "☀️";
+          darkModeToggle.setAttribute(
+            "aria-label",
+            currentTranslations["light_mode_toggle"] || "Switch to Light Mode"
+          );
+        } else {
+          darkModeToggle.textContent = "🌙";
+          darkModeToggle.setAttribute(
+            "aria-label",
+            currentTranslations["dark_mode_toggle"] || "Switch to Dark Mode"
+          );
+        }
+      }
+
+      async function setLanguage(lang) {
+        const translations = await fetchTranslations(lang);
+        if (translations) {
+          applyTranslations(translations);
+          localStorage.setItem("language", lang);
+          document.documentElement.lang = lang;
+
+          document
+            .querySelectorAll("#language-switcher button")
+            .forEach((btn) => {
+              btn.classList.remove("active");
+              if (btn.getAttribute("data-lang") === lang) {
+                btn.classList.add("active");
+              }
+            });
+        }
+      }
+
+      if (localStorage.getItem("darkMode") === "enabled") {
+        body.classList.add("dark-mode");
+      }
+
+      darkModeToggle.addEventListener("click", () => {
+        body.classList.toggle("dark-mode");
+        if (body.classList.contains("dark-mode")) {
+          localStorage.setItem("darkMode", "enabled");
+        } else {
+          localStorage.setItem("darkMode", "disabled");
+        }
+        updateDarkModeButtonIcon();
+      });
+
+      const languageSwitcher = document.getElementById("language-switcher");
+      if (languageSwitcher) {
+        languageSwitcher.addEventListener("click", (event) => {
+          const button = event.target.closest("button[data-lang]");
+          if (button) {
+            const lang = button.getAttribute("data-lang");
+            setLanguage(lang);
+          }
+        });
+      }
+
+      async function initializeApp() {
+        const preferredLang = localStorage.getItem("language") || "en";
+        document.documentElement.lang = preferredLang;
+
+        await generateNavigation();
+        await setLanguage(preferredLang);
+      }
+
+      initializeApp();
+
+      const hamburgerMenu = document.querySelector(".hamburger-menu");
+      const navItemsContainer = document.querySelector(".nav-items");
+
+      if (hamburgerMenu && navItemsContainer) {
+        hamburgerMenu.addEventListener("click", () => {
+          navItemsContainer.classList.toggle("active");
+          const isExpanded = navItemsContainer.classList.contains("active");
+          hamburgerMenu.setAttribute("aria-expanded", isExpanded);
+        });
+      }
+
+      const contactForm = document.querySelector(".contact-form form");
+      if (contactForm) {
+        contactForm.addEventListener("submit", function (event) {
+          const name = document.getElementById("name").value.trim();
+          const email = document.getElementById("email").value.trim();
+          const message = document.getElementById("message").value.trim();
+          let isValid = true;
+          let errors = [];
+
+          if (name === "") {
+            isValid = false;
+            errors.push("Name is required.");
+          }
+
+          if (email === "") {
+            isValid = false;
+            errors.push("Email is required.");
+          } else {
+            const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            if (!emailPattern.test(email)) {
+              isValid = false;
+              errors.push("Please enter a valid email address.");
+            }
+          }
+
+          if (message === "") {
+            isValid = false;
+            errors.push("Message is required.");
+          }
+
+          if (!isValid) {
+            event.preventDefault();
+            alert(
+              "Please correct the following errors:\n\n" + errors.join("\n")
+            );
+          }
+        });
+      }
+    </script>
+    {% endblock scripts %}
+</body>
+</html>

--- a/templates/blocks/blog.html
+++ b/templates/blocks/blog.html
@@ -1,11 +1,15 @@
 <section class="blog" id="blog">
-  <h2 data-i18n="blog_title">{{ translations.get('blog_title', 'Latest Posts') }}</h2>
+  <h2 data-i18n="blog_title">
+    {{ translations.get('blog_title', 'Latest Posts') }}
+  </h2>
   <div class="blog-list">
     {% for post in items %}
     <div class="blog-item" id="{{ post.id if post.id else '' }}">
       <h3>{{ translations.get(post.title.key, post.title.key) }}</h3>
       <p>{{ translations.get(post.excerpt.key, post.excerpt.key) }}</p>
-      <a href="{{ post.cta.uri }}" class="read-more">{{ translations.get(post.cta.text.key, post.cta.text.key) }}</a>
+      <a href="{{ post.cta.uri }}" class="read-more"
+        >{{ translations.get(post.cta.text.key, post.cta.text.key) }}</a
+      >
     </div>
     {% else %}
     <!-- No blog posts provided -->

--- a/templates/blocks/blog.html
+++ b/templates/blocks/blog.html
@@ -1,0 +1,14 @@
+<section class="blog" id="blog">
+  <h2 data-i18n="blog_title">{{ translations.get('blog_title', 'Latest Posts') }}</h2>
+  <div class="blog-list">
+    {% for post in items %}
+    <div class="blog-item" id="{{ post.id if post.id else '' }}">
+      <h3>{{ translations.get(post.title.key, post.title.key) }}</h3>
+      <p>{{ translations.get(post.excerpt.key, post.excerpt.key) }}</p>
+      <a href="{{ post.cta.uri }}" class="read-more">{{ translations.get(post.cta.text.key, post.cta.text.key) }}</a>
+    </div>
+    {% else %}
+    <!-- No blog posts provided -->
+    {% endfor %}
+  </div>
+</section>

--- a/templates/blocks/contact-form.html
+++ b/templates/blocks/contact-form.html
@@ -1,0 +1,73 @@
+<section class="contact-form" id="contact">
+  <h2 data-i18n="contact_title">{{ translations.get('contact_title', 'Contact Us') }}</h2>
+  <form id="contactForm" method="POST"
+        action="{{ config.form_action_uri if config and config.form_action_uri else '#' }}"
+        data-form-action-url="{{ config.form_action_uri if config and config.form_action_uri else '#' }}"
+        data-success-message="{{ translations.get(config.success_message_key, 'Message sent!') if config else 'Message sent!' }}"
+        data-error-message="{{ translations.get(config.error_message_key, 'Error sending message.') if config else 'Error sending message.' }}">
+
+    <label for="name" data-i18n="contact_name_label">{{ translations.get('contact_name_label', 'Name:') }}</label>
+    <input type="text" id="name" name="name" required />
+
+    <label for="email" data-i18n="contact_email_label">{{ translations.get('contact_email_label', 'Email:') }}</label>
+    <input type="email" id="email" name="email" required />
+
+    <label for="message" data-i18n="contact_message_label">{{ translations.get('contact_message_label', 'Message:') }}</label>
+    <textarea id="message" name="message" rows="4" required></textarea>
+
+    <button type="submit" data-i18n="contact_send_button">{{ translations.get('contact_send_button', 'Send Message') }}</button>
+    <div id="contactFormStatus" role="status"></div>
+  </form>
+</section>
+
+{# The script part remains the same as it's client-side JavaScript #}
+{# It's already designed to pick up data attributes from the form tag #}
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const form = document.getElementById("contactForm");
+    if (form) {
+      const statusDiv = document.getElementById("contactFormStatus");
+      // These are now read from the form's data attributes, which are set by Jinja2
+      const actionUrl = form.dataset.formActionUrl;
+      const successMessage = form.dataset.successMessage;
+      const errorMessage = form.dataset.errorMessage;
+
+      form.addEventListener("submit", function (event) {
+        event.preventDefault();
+        const formData = new FormData(form);
+        statusDiv.textContent = "";
+        statusDiv.classList.remove("success", "error");
+
+        fetch(actionUrl, {
+          method: "POST",
+          body: formData,
+          headers: {
+            Accept: "application/json",
+          },
+        })
+          .then((response) => {
+            if (response.ok) {
+              statusDiv.textContent = successMessage;
+              statusDiv.classList.add("success");
+              form.reset();
+            } else {
+              response.json().then((data) => {
+                if (Object.hasOwn(data, "errors")) {
+                  statusDiv.textContent = data["errors"]
+                    .map((error) => error["message"])
+                    .join(", ");
+                } else {
+                  statusDiv.textContent = errorMessage;
+                }
+                statusDiv.classList.add("error");
+              });
+            }
+          })
+          .catch((error) => {
+            statusDiv.textContent = errorMessage;
+            statusDiv.classList.add("error");
+          });
+      });
+    }
+  });
+</script>

--- a/templates/blocks/contact-form.html
+++ b/templates/blocks/contact-form.html
@@ -1,27 +1,39 @@
 <section class="contact-form" id="contact">
-  <h2 data-i18n="contact_title">{{ translations.get('contact_title', 'Contact Us') }}</h2>
-  <form id="contactForm" method="POST"
-        action="{{ config.form_action_uri if config and config.form_action_uri else '#' }}"
-        data-form-action-url="{{ config.form_action_uri if config and config.form_action_uri else '#' }}"
-        data-success-message="{{ translations.get(config.success_message_key, 'Message sent!') if config else 'Message sent!' }}"
-        data-error-message="{{ translations.get(config.error_message_key, 'Error sending message.') if config else 'Error sending message.' }}">
-
-    <label for="name" data-i18n="contact_name_label">{{ translations.get('contact_name_label', 'Name:') }}</label>
+  <h2 data-i18n="contact_title">
+    {{ translations.get('contact_title', 'Contact Us') }}
+  </h2>
+  <form
+    id="contactForm"
+    method="POST"
+    action="{{ config.form_action_uri if config and config.form_action_uri else '#' }}"
+    data-form-action-url="{{ config.form_action_uri if config and config.form_action_uri else '#' }}"
+    data-success-message="{{ translations.get(config.success_message_key, 'Message sent!') if config else 'Message sent!' }}"
+    data-error-message="{{ translations.get(config.error_message_key, 'Error sending message.') if config else 'Error sending message.' }}"
+  >
+    <label for="name" data-i18n="contact_name_label"
+      >{{ translations.get('contact_name_label', 'Name:') }}</label
+    >
     <input type="text" id="name" name="name" required />
 
-    <label for="email" data-i18n="contact_email_label">{{ translations.get('contact_email_label', 'Email:') }}</label>
+    <label for="email" data-i18n="contact_email_label"
+      >{{ translations.get('contact_email_label', 'Email:') }}</label
+    >
     <input type="email" id="email" name="email" required />
 
-    <label for="message" data-i18n="contact_message_label">{{ translations.get('contact_message_label', 'Message:') }}</label>
+    <label for="message" data-i18n="contact_message_label"
+      >{{ translations.get('contact_message_label', 'Message:') }}</label
+    >
     <textarea id="message" name="message" rows="4" required></textarea>
 
-    <button type="submit" data-i18n="contact_send_button">{{ translations.get('contact_send_button', 'Send Message') }}</button>
+    <button type="submit" data-i18n="contact_send_button">
+      {{ translations.get('contact_send_button', 'Send Message') }}
+    </button>
     <div id="contactFormStatus" role="status"></div>
   </form>
 </section>
 
-{# The script part remains the same as it's client-side JavaScript #}
-{# It's already designed to pick up data attributes from the form tag #}
+{# The script part remains the same as it's client-side JavaScript #} {# It's
+already designed to pick up data attributes from the form tag #}
 <script>
   document.addEventListener("DOMContentLoaded", function () {
     const form = document.getElementById("contactForm");

--- a/templates/blocks/features.html
+++ b/templates/blocks/features.html
@@ -1,0 +1,16 @@
+<section class="features" id="features" data-aos="fade-up" data-aos-delay="100">
+  <h2 data-i18n="features_title">{{ translations.get('features_title', 'Features') }}</h2>
+  <div class="feature-list">
+    {% for item in items %}
+    <div class="feature-item">
+      {% if item.icon and item.icon.svg_content %}
+      {{ item.icon.svg_content | safe }}
+      {% endif %}
+      <h3>{{ translations.get(item.content.title.key, item.content.title.key) }}</h3>
+      <p>{{ translations.get(item.content.description.key, item.content.description.key) }}</p>
+    </div>
+    {% else %}
+    <!-- No feature items provided -->
+    {% endfor %}
+  </div>
+</section>

--- a/templates/blocks/features.html
+++ b/templates/blocks/features.html
@@ -1,13 +1,19 @@
 <section class="features" id="features" data-aos="fade-up" data-aos-delay="100">
-  <h2 data-i18n="features_title">{{ translations.get('features_title', 'Features') }}</h2>
+  <h2 data-i18n="features_title">
+    {{ translations.get('features_title', 'Features') }}
+  </h2>
   <div class="feature-list">
     {% for item in items %}
     <div class="feature-item">
-      {% if item.icon and item.icon.svg_content %}
-      {{ item.icon.svg_content | safe }}
-      {% endif %}
-      <h3>{{ translations.get(item.content.title.key, item.content.title.key) }}</h3>
-      <p>{{ translations.get(item.content.description.key, item.content.description.key) }}</p>
+      {% if item.icon and item.icon.svg_content %} {{ item.icon.svg_content |
+      safe }} {% endif %}
+      <h3>
+        {{ translations.get(item.content.title.key, item.content.title.key) }}
+      </h3>
+      <p>
+        {{ translations.get(item.content.description.key,
+        item.content.description.key) }}
+      </p>
     </div>
     {% else %}
     <!-- No feature items provided -->

--- a/templates/blocks/hero.html
+++ b/templates/blocks/hero.html
@@ -1,0 +1,10 @@
+<section class="hero">
+    {% if hero_item %}
+    <h1>{{ translations.get(hero_item.title.key, hero_item.title.key) }}</h1>
+    <p>{{ translations.get(hero_item.subtitle.key, hero_item.subtitle.key) }}</p>
+    <a href="{{ hero_item.cta.uri }}" class="cta-button">{{ translations.get(hero_item.cta.text.key, hero_item.cta.text.key) }}</a>
+    <!-- Selected variation: {{ hero_item.variation_id }} -->
+    {% else %}
+    <!-- Hero data not found or no variations -->
+    {% endif %}
+</section>

--- a/templates/blocks/hero.html
+++ b/templates/blocks/hero.html
@@ -1,10 +1,12 @@
 <section class="hero">
-    {% if hero_item %}
-    <h1>{{ translations.get(hero_item.title.key, hero_item.title.key) }}</h1>
-    <p>{{ translations.get(hero_item.subtitle.key, hero_item.subtitle.key) }}</p>
-    <a href="{{ hero_item.cta.uri }}" class="cta-button">{{ translations.get(hero_item.cta.text.key, hero_item.cta.text.key) }}</a>
-    <!-- Selected variation: {{ hero_item.variation_id }} -->
-    {% else %}
-    <!-- Hero data not found or no variations -->
-    {% endif %}
+  {% if hero_item %}
+  <h1>{{ translations.get(hero_item.title.key, hero_item.title.key) }}</h1>
+  <p>{{ translations.get(hero_item.subtitle.key, hero_item.subtitle.key) }}</p>
+  <a href="{{ hero_item.cta.uri }}" class="cta-button"
+    >{{ translations.get(hero_item.cta.text.key, hero_item.cta.text.key) }}</a
+  >
+  <!-- Selected variation: {{ hero_item.variation_id }} -->
+  {% else %}
+  <!-- Hero data not found or no variations -->
+  {% endif %}
 </section>

--- a/templates/blocks/portfolio.html
+++ b/templates/blocks/portfolio.html
@@ -1,11 +1,21 @@
 <section class="portfolio" id="portfolio">
-  <h2 data-i18n="portfolio_title">{{ translations.get('portfolio_title', 'Our Work') }}</h2>
+  <h2 data-i18n="portfolio_title">
+    {{ translations.get('portfolio_title', 'Our Work') }}
+  </h2>
   <div class="portfolio-grid">
     {% for item in items %}
     <div class="portfolio-item" id="{{ item.id if item.id else '' }}">
-      <img src="{{ item.image.src }}" alt="{{ translations.get(item.image.alt_text.key, 'Portfolio image') }}">
-      <h3>{{ translations.get(item.details.title.key, item.details.title.key) }}</h3>
-      <p>{{ translations.get(item.details.description.key, item.details.description.key) }}</p>
+      <img
+        src="{{ item.image.src }}"
+        alt="{{ translations.get(item.image.alt_text.key, 'Portfolio image') }}"
+      />
+      <h3>
+        {{ translations.get(item.details.title.key, item.details.title.key) }}
+      </h3>
+      <p>
+        {{ translations.get(item.details.description.key,
+        item.details.description.key) }}
+      </p>
     </div>
     {% else %}
     <!-- No portfolio items provided -->

--- a/templates/blocks/portfolio.html
+++ b/templates/blocks/portfolio.html
@@ -1,0 +1,14 @@
+<section class="portfolio" id="portfolio">
+  <h2 data-i18n="portfolio_title">{{ translations.get('portfolio_title', 'Our Work') }}</h2>
+  <div class="portfolio-grid">
+    {% for item in items %}
+    <div class="portfolio-item" id="{{ item.id if item.id else '' }}">
+      <img src="{{ item.image.src }}" alt="{{ translations.get(item.image.alt_text.key, 'Portfolio image') }}">
+      <h3>{{ translations.get(item.details.title.key, item.details.title.key) }}</h3>
+      <p>{{ translations.get(item.details.description.key, item.details.description.key) }}</p>
+    </div>
+    {% else %}
+    <!-- No portfolio items provided -->
+    {% endfor %}
+  </div>
+</section>

--- a/templates/blocks/testimonials.html
+++ b/templates/blocks/testimonials.html
@@ -1,0 +1,14 @@
+<section class="testimonials" id="testimonials">
+  <h2 data-i18n="testimonials_title">{{ translations.get('testimonials_title', 'Testimonials') }}</h2>
+  <div class="testimonial-list">
+    {% for item in items %}
+    <div class="testimonial-item">
+      <img src="{{ item.author_image.src }}" alt="{{ translations.get(item.author_image.alt_text.key, 'User photo') }}">
+      <p>"{{ translations.get(item.text.key, item.text.key) }}"</p>
+      <h4>{{ translations.get(item.author.key, item.author.key) }}</h4>
+    </div>
+    {% else %}
+    <!-- No testimonial items provided -->
+    {% endfor %}
+  </div>
+</section>

--- a/templates/blocks/testimonials.html
+++ b/templates/blocks/testimonials.html
@@ -1,9 +1,14 @@
 <section class="testimonials" id="testimonials">
-  <h2 data-i18n="testimonials_title">{{ translations.get('testimonials_title', 'Testimonials') }}</h2>
+  <h2 data-i18n="testimonials_title">
+    {{ translations.get('testimonials_title', 'Testimonials') }}
+  </h2>
   <div class="testimonial-list">
     {% for item in items %}
     <div class="testimonial-item">
-      <img src="{{ item.author_image.src }}" alt="{{ translations.get(item.author_image.alt_text.key, 'User photo') }}">
+      <img
+        src="{{ item.author_image.src }}"
+        alt="{{ translations.get(item.author_image.alt_text.key, 'User photo') }}"
+      />
       <p>"{{ translations.get(item.text.key, item.text.key) }}"</p>
       <h4>{{ translations.get(item.author.key, item.author.key) }}</h4>
     </div>

--- a/test_build.py
+++ b/test_build.py
@@ -97,15 +97,21 @@ class TestBuildScript(unittest.TestCase):
         # Ensure a dummy 'templates' dir exists for FileSystemLoader, or use a mock loader.
         # For simplicity, assuming 'templates' might be a general dir or we mock rendering.
         # Let's create a dummy templates dir for the loader to be valid.
-        os.makedirs(os.path.join(self.test_root_dir, "templates", "blocks"), exist_ok=True)
-        self.jinja_env = Environment(loader=FileSystemLoader(os.path.join(self.test_root_dir, "templates")))
+        os.makedirs(
+            os.path.join(self.test_root_dir, "templates", "blocks"), exist_ok=True
+        )
+        self.jinja_env = Environment(
+            loader=FileSystemLoader(os.path.join(self.test_root_dir, "templates"))
+        )
 
         self.translation_provider = DefaultTranslationProvider()
         self.data_loader = JsonProtoDataLoader[Message]()
         self.portfolio_generator = PortfolioHtmlGenerator(jinja_env=self.jinja_env)
         self.blog_generator = BlogHtmlGenerator(jinja_env=self.jinja_env)
         self.features_generator = FeaturesHtmlGenerator(jinja_env=self.jinja_env)
-        self.testimonials_generator = TestimonialsHtmlGenerator(jinja_env=self.jinja_env)
+        self.testimonials_generator = TestimonialsHtmlGenerator(
+            jinja_env=self.jinja_env
+        )
         self.hero_generator = HeroHtmlGenerator(jinja_env=self.jinja_env)
         self.contact_form_generator = ContactFormHtmlGenerator(jinja_env=self.jinja_env)
 

--- a/test_build.py
+++ b/test_build.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 from google.protobuf import json_format
 from google.protobuf.message import Message  # Explicit import for T = TypeVar bound
+from jinja2 import Environment, FileSystemLoader
 
 from build import main as build_main
 from build_protocols.data_loading import JsonProtoDataLoader
@@ -88,14 +89,25 @@ class TestBuildScript(unittest.TestCase):
 
     def _instantiate_services(self) -> None:
         """Instantiates common service components used in tests."""
+        # Create a dummy Jinja2 environment for testing generators
+        # It needs a loader, even if templates aren't actually loaded in all unit tests.
+        # The "templates" directory is assumed to exist or be created by test setup if needed.
+        # For many generator unit tests, the actual rendering might be mocked,
+        # but the constructor needs the env.
+        # Ensure a dummy 'templates' dir exists for FileSystemLoader, or use a mock loader.
+        # For simplicity, assuming 'templates' might be a general dir or we mock rendering.
+        # Let's create a dummy templates dir for the loader to be valid.
+        os.makedirs(os.path.join(self.test_root_dir, "templates", "blocks"), exist_ok=True)
+        self.jinja_env = Environment(loader=FileSystemLoader(os.path.join(self.test_root_dir, "templates")))
+
         self.translation_provider = DefaultTranslationProvider()
         self.data_loader = JsonProtoDataLoader[Message]()
-        self.portfolio_generator = PortfolioHtmlGenerator()
-        self.blog_generator = BlogHtmlGenerator()
-        self.features_generator = FeaturesHtmlGenerator()
-        self.testimonials_generator = TestimonialsHtmlGenerator()
-        self.hero_generator = HeroHtmlGenerator()
-        self.contact_form_generator = ContactFormHtmlGenerator()
+        self.portfolio_generator = PortfolioHtmlGenerator(jinja_env=self.jinja_env)
+        self.blog_generator = BlogHtmlGenerator(jinja_env=self.jinja_env)
+        self.features_generator = FeaturesHtmlGenerator(jinja_env=self.jinja_env)
+        self.testimonials_generator = TestimonialsHtmlGenerator(jinja_env=self.jinja_env)
+        self.hero_generator = HeroHtmlGenerator(jinja_env=self.jinja_env)
+        self.contact_form_generator = ContactFormHtmlGenerator(jinja_env=self.jinja_env)
 
     def _create_dummy_translation_files(self) -> None:
         """Creates dummy translation JSON files (en.json, es.json)."""


### PR DESCRIPTION
Partial refactor of the site build system to use Jinja2 for templating, replacing BeautifulSoup for HTML parsing and assembly.

Key changes:
- Added Jinja2 dependency.
- Converted index.html to templates/base.html (Jinja2).
- Converted block files (e.g., hero.html, features.html) to Jinja2 templates under templates/blocks/.
- Updated HtmlBlockGenerator classes to use Jinja2 for rendering.
- Refactored DefaultPageBuilder to use Jinja2 for page assembly, removing BeautifulSoup.
- Updated BuildOrchestrator and main function in build.py to support the new Jinja2-based workflow.

Work is currently blocked by an issue where the Protobuf files are not being compiled, leading to a ModuleNotFoundError for the 'generated' module. Further investigation is needed to find and run the Protobuf compilation step.