### PR TITLE
Fix: Resolve various MyPy errors

### DIFF
--- a/build_protocols/html_generation.py
+++ b/build_protocols/html_generation.py
@@ -43,7 +43,7 @@ class PortfolioHtmlGenerator(HtmlBlockGenerator):
             An HTML string representing the portfolio items.
         """
         template = self.jinja_env.get_template("blocks/portfolio.html")
-        return template.render(items=data, translations=translations)
+        return str(template.render(items=data, translations=translations))
 
 
 class TestimonialsHtmlGenerator(HtmlBlockGenerator):
@@ -65,7 +65,7 @@ class TestimonialsHtmlGenerator(HtmlBlockGenerator):
             An HTML string representing the testimonial items.
         """
         template = self.jinja_env.get_template("blocks/testimonials.html")
-        return template.render(items=data, translations=translations)
+        return str(template.render(items=data, translations=translations))
 
 
 class FeaturesHtmlGenerator(HtmlBlockGenerator):
@@ -85,7 +85,7 @@ class FeaturesHtmlGenerator(HtmlBlockGenerator):
             An HTML string representing the feature items.
         """
         template = self.jinja_env.get_template("blocks/features.html")
-        return template.render(items=data, translations=translations)
+        return str(template.render(items=data, translations=translations))
 
 
 class HeroHtmlGenerator(HtmlBlockGenerator):
@@ -106,24 +106,27 @@ class HeroHtmlGenerator(HtmlBlockGenerator):
         Returns:
             An HTML string for the hero section.
         """
+        selected_variation: Optional[HeroItemContent] = None  # Define type once at the correct scope
+
         if not data or not data.variations:
-            # This case should ideally be handled by the template,
-            # but can be pre-checked.
-            # For simplicity, passing None to template if no data.
-            selected_variation = None
+            # selected_variation remains None, which is handled by the template
+            pass
         else:
-            selected_variation: Optional[HeroItemContent] = None
+            # Attempt to find and set the selected_variation
             if data.default_variation_id:
                 for var in data.variations:
                     if var.variation_id == data.default_variation_id:
                         selected_variation = var
                         break
+
+            # If no specific variation was found yet (e.g. default_variation_id didn't match or wasn't set)
+            # and variations are available, pick one randomly.
             if not selected_variation and data.variations:
                 selected_variation = random.choice(data.variations)
 
         template = self.jinja_env.get_template("blocks/hero.html")
         # The template expects `hero_item` as the context variable for the selected variation
-        return template.render(hero_item=selected_variation, translations=translations)
+        return str(template.render(hero_item=selected_variation, translations=translations))
 
 
 class ContactFormHtmlGenerator(HtmlBlockGenerator):
@@ -146,7 +149,7 @@ class ContactFormHtmlGenerator(HtmlBlockGenerator):
         """
         template = self.jinja_env.get_template("blocks/contact-form.html")
         # The template expects `config` for the ContactFormConfig data
-        return template.render(config=data, translations=translations)
+        return str(template.render(config=data, translations=translations))
 
 
 class BlogHtmlGenerator(HtmlBlockGenerator):
@@ -166,4 +169,4 @@ class BlogHtmlGenerator(HtmlBlockGenerator):
             An HTML string representing the blog posts.
         """
         template = self.jinja_env.get_template("blocks/blog.html")
-        return template.render(items=data, translations=translations)
+        return str(template.render(items=data, translations=translations))

--- a/build_protocols/interfaces.py
+++ b/build_protocols/interfaces.py
@@ -204,6 +204,7 @@ class PageBuilder(Protocol):
         main_content: str,
         header_content: Optional[str] = None,
         footer_content: Optional[str] = None,
+        page_title: Optional[str] = None,
     ) -> str:
         """Assembles a full HTML page using translated and generated content.
 

--- a/build_protocols/page_assembly.py
+++ b/build_protocols/page_assembly.py
@@ -115,4 +115,4 @@ class DefaultPageBuilder(PageBuilder):
         # Server-side translation of base.html structure can be done by passing translations
         # to its render context (as done above).
 
-        return base_template.render(context)
+        return str(base_template.render(context))

--- a/test_build.py
+++ b/test_build.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 from google.protobuf import json_format
 from google.protobuf.message import Message  # Explicit import for T = TypeVar bound
+from jinja2 import Environment, FileSystemLoader
 
 from build import main as build_main
 from build_protocols.data_loading import JsonProtoDataLoader
@@ -88,14 +89,25 @@ class TestBuildScript(unittest.TestCase):
 
     def _instantiate_services(self) -> None:
         """Instantiates common service components used in tests."""
+        # Create a dummy Jinja2 environment for testing generators
+        # It needs a loader, even if templates aren't actually loaded in all unit tests.
+        # The "templates" directory is assumed to exist or be created by test setup if needed.
+        # For many generator unit tests, the actual rendering might be mocked,
+        # but the constructor needs the env.
+        # Ensure a dummy 'templates' dir exists for FileSystemLoader, or use a mock loader.
+        # For simplicity, assuming 'templates' might be a general dir or we mock rendering.
+        # Let's create a dummy templates dir for the loader to be valid.
+        os.makedirs(os.path.join(self.test_root_dir, "templates", "blocks"), exist_ok=True)
+        self.jinja_env = Environment(loader=FileSystemLoader(os.path.join(self.test_root_dir, "templates")))
+
         self.translation_provider = DefaultTranslationProvider()
         self.data_loader = JsonProtoDataLoader[Message]()
-        self.portfolio_generator = PortfolioHtmlGenerator()
-        self.blog_generator = BlogHtmlGenerator()
-        self.features_generator = FeaturesHtmlGenerator()
-        self.testimonials_generator = TestimonialsHtmlGenerator()
-        self.hero_generator = HeroHtmlGenerator()
-        self.contact_form_generator = ContactFormHtmlGenerator()
+        self.portfolio_generator = PortfolioHtmlGenerator(jinja_env=self.jinja_env)
+        self.blog_generator = BlogHtmlGenerator(jinja_env=self.jinja_env)
+        self.features_generator = FeaturesHtmlGenerator(jinja_env=self.jinja_env)
+        self.testimonials_generator = TestimonialsHtmlGenerator(jinja_env=self.jinja_env)
+        self.hero_generator = HeroHtmlGenerator(jinja_env=self.jinja_env)
+        self.contact_form_generator = ContactFormHtmlGenerator(jinja_env=self.jinja_env)
 
     def _create_dummy_translation_files(self) -> None:
         """Creates dummy translation JSON files (en.json, es.json)."""


### PR DESCRIPTION
- Fix no-redef error in html_generation.py for `selected_variation`.
- Fix call-arg error in build.py by aligning PageBuilder protocol with its implementation for `page_title`.
- Fix call-arg errors in test_build.py by providing `jinja_env` to HTML generator constructors.
- Correct syntax error (unindent) in html_generation.py introduced during fixes.
- Resolve no-any-return errors by casting Jinja2 `render()` output to `str` in html_generation.py and page_assembly.py.