### PR TITLE
Fix: Resolve multiple test failures in test_build.py

### DIFF
--- a/build_protocols/html_generation.py
+++ b/build_protocols/html_generation.py
@@ -42,6 +42,8 @@ class PortfolioHtmlGenerator(HtmlBlockGenerator):
         Returns:
             An HTML string representing the portfolio items.
         """
+        if not data:
+            return ""
         template = self.jinja_env.get_template("blocks/portfolio.html")
         return str(template.render(items=data, translations=translations))
 
@@ -64,6 +66,8 @@ class TestimonialsHtmlGenerator(HtmlBlockGenerator):
         Returns:
             An HTML string representing the testimonial items.
         """
+        if not data:
+            return ""
         template = self.jinja_env.get_template("blocks/testimonials.html")
         return str(template.render(items=data, translations=translations))
 
@@ -84,6 +88,8 @@ class FeaturesHtmlGenerator(HtmlBlockGenerator):
         Returns:
             An HTML string representing the feature items.
         """
+        if not data:
+            return ""
         template = self.jinja_env.get_template("blocks/features.html")
         return str(template.render(items=data, translations=translations))
 
@@ -106,25 +112,22 @@ class HeroHtmlGenerator(HtmlBlockGenerator):
         Returns:
             An HTML string for the hero section.
         """
-        selected_variation: Optional[HeroItemContent] = (
-            None  # Define type once at the correct scope
-        )
-
         if not data or not data.variations:
-            # selected_variation remains None, which is handled by the template
-            pass
-        else:
-            # Attempt to find and set the selected_variation
-            if data.default_variation_id:
-                for var in data.variations:
-                    if var.variation_id == data.default_variation_id:
-                        selected_variation = var
-                        break
+            return "<!-- Hero data not found or no variations -->"
 
-            # If no specific variation was found yet (e.g. default_variation_id didn't match or wasn't set)
-            # and variations are available, pick one randomly.
-            if not selected_variation and data.variations:
-                selected_variation = random.choice(data.variations)
+        selected_variation: Optional[HeroItemContent] = None
+
+        # Attempt to find and set the selected_variation
+        if data.default_variation_id:
+            for var in data.variations:
+                if var.variation_id == data.default_variation_id:
+                    selected_variation = var
+                    break
+
+        # If no specific variation was found yet (e.g. default_variation_id didn't match or wasn't set)
+        # and variations are available, pick one randomly. (This condition also ensures data.variations is not empty)
+        if not selected_variation: # Already know data.variations is not empty from the guard clause
+            selected_variation = random.choice(data.variations)
 
         template = self.jinja_env.get_template("blocks/hero.html")
         # The template expects `hero_item` as the context variable for the selected variation
@@ -151,6 +154,8 @@ class ContactFormHtmlGenerator(HtmlBlockGenerator):
         Returns:
             An HTML string representing the contact form section.
         """
+        if not data:
+            return ""
         template = self.jinja_env.get_template("blocks/contact-form.html")
         # The template expects `config` for the ContactFormConfig data
         return str(template.render(config=data, translations=translations))
@@ -172,5 +177,7 @@ class BlogHtmlGenerator(HtmlBlockGenerator):
         Returns:
             An HTML string representing the blog posts.
         """
+        if not data:
+            return ""
         template = self.jinja_env.get_template("blocks/blog.html")
         return str(template.render(items=data, translations=translations))

--- a/test_build.py
+++ b/test_build.py
@@ -87,7 +87,9 @@ class TestBuildScript(unittest.TestCase):
         # os.makedirs(self.test_blocks_dir, exist_ok=True) # Not needed
         os.makedirs(self.test_public_generated_configs_dir, exist_ok=True)
         # Ensure the target directory for dummy block templates exists
-        os.makedirs(os.path.join(self.test_root_dir, "templates", "blocks"), exist_ok=True)
+        os.makedirs(
+            os.path.join(self.test_root_dir, "templates", "blocks"), exist_ok=True
+        )
 
     def _instantiate_services(self) -> None:
         """Instantiates common service components used in tests."""
@@ -344,7 +346,9 @@ class TestBuildScript(unittest.TestCase):
     def _create_dummy_block_files(self) -> None:
         """Creates dummy HTML block files in templates/blocks/ directory."""
         # The directory templates/blocks is created in _create_test_directories
-        dummy_blocks_dir = os.path.join("templates", "blocks") # Relative to self.test_root_dir
+        dummy_blocks_dir = os.path.join(
+            "templates", "blocks"
+        )  # Relative to self.test_root_dir
 
         # For hero.html, matching the context from HeroHtmlGenerator and test assertions
         hero_template_content = """
@@ -359,7 +363,9 @@ class TestBuildScript(unittest.TestCase):
     {% endif %}
 </section>
 """
-        with open(os.path.join(dummy_blocks_dir, "hero.html"), "w", encoding="utf-8") as f:
+        with open(
+            os.path.join(dummy_blocks_dir, "hero.html"), "w", encoding="utf-8"
+        ) as f:
             f.write(hero_template_content)
 
         # For list-based items, the generators pass `items` to the template.
@@ -380,7 +386,9 @@ class TestBuildScript(unittest.TestCase):
     {% endfor %}
 </div>
 """
-        with open(os.path.join(dummy_blocks_dir, "features.html"), "w", encoding="utf-8") as f:
+        with open(
+            os.path.join(dummy_blocks_dir, "features.html"), "w", encoding="utf-8"
+        ) as f:
             f.write(features_template_content)
 
         # test_generate_testimonials_html asserts:
@@ -401,7 +409,9 @@ class TestBuildScript(unittest.TestCase):
     {% endfor %}
 </div>
 """
-        with open(os.path.join(dummy_blocks_dir, "testimonials.html"), "w", encoding="utf-8") as f:
+        with open(
+            os.path.join(dummy_blocks_dir, "testimonials.html"), "w", encoding="utf-8"
+        ) as f:
             f.write(testimonials_template_content)
 
         # test_generate_portfolio_html asserts:
@@ -422,7 +432,9 @@ class TestBuildScript(unittest.TestCase):
     {% endfor %}
 </div>
 """
-        with open(os.path.join(dummy_blocks_dir, "portfolio.html"), "w", encoding="utf-8") as f:
+        with open(
+            os.path.join(dummy_blocks_dir, "portfolio.html"), "w", encoding="utf-8"
+        ) as f:
             f.write(portfolio_template_content)
 
         # test_generate_blog_html asserts:
@@ -443,7 +455,9 @@ class TestBuildScript(unittest.TestCase):
     {% endfor %}
 </div>
 """
-        with open(os.path.join(dummy_blocks_dir, "blog.html"), "w", encoding="utf-8") as f:
+        with open(
+            os.path.join(dummy_blocks_dir, "blog.html"), "w", encoding="utf-8"
+        ) as f:
             f.write(blog_template_content)
 
         # ContactFormHtmlGenerator passes `config` to template.
@@ -457,9 +471,10 @@ class TestBuildScript(unittest.TestCase):
     {% endif %}
 </form>
 """
-        with open(os.path.join(dummy_blocks_dir, "contact-form.html"), "w", encoding="utf-8") as f:
+        with open(
+            os.path.join(dummy_blocks_dir, "contact-form.html"), "w", encoding="utf-8"
+        ) as f:
             f.write(contact_form_template_content)
-
 
     def tearDown(self) -> None:
         """Clean up the temporary test environment after each test."""
@@ -794,9 +809,7 @@ class TestBuildScript(unittest.TestCase):
         mock_testimonial_item = TestimonialItem(text={"key": "ttk"})
         mock_hero_item = HeroItem(
             default_variation_id="v1",
-            variations=[
-                HeroItemContent(variation_id="v1", title={"key": "htk"})
-            ],
+            variations=[HeroItemContent(variation_id="v1", title={"key": "htk"})],
         )  # type: ignore
         mock_contact_config = ContactFormConfig(
             form_action_uri="/test_action",
@@ -828,9 +841,7 @@ class TestBuildScript(unittest.TestCase):
                 return mock_navigation_data
             return None
 
-        mock_load_single_item_data.side_effect = (
-            load_single_item_data_side_effect
-        )
+        mock_load_single_item_data.side_effect = load_single_item_data_side_effect
 
         mock_data_cache_preload.return_value = None
 
@@ -849,20 +860,14 @@ class TestBuildScript(unittest.TestCase):
                 return mock_contact_config
             return None
 
-        mock_data_cache_get_item.side_effect = (
-            data_cache_get_item_side_effect
-        )
+        mock_data_cache_get_item.side_effect = data_cache_get_item_side_effect
 
         mock_gen_portfolio_html.return_value = "<p>Portfolio Content</p>"
         mock_gen_blog_html.return_value = "<p>Blog Content</p>"
         mock_gen_features_html.return_value = "<p>Features Content</p>"
-        mock_gen_testimonials_html.return_value = (
-            "<p>Testimonials Content</p>"
-        )
+        mock_gen_testimonials_html.return_value = "<p>Testimonials Content</p>"
         mock_gen_hero_html.return_value = "<p>Hero Content</p>"
-        mock_gen_contact_html.return_value = (
-            'data-form-id="contact-form-attrs"'
-        )
+        mock_gen_contact_html.return_value = 'data-form-id="contact-form-attrs"'
         mock_generate_lang_config.return_value = {
             "lang": "test",
             "ui_strings": {},
@@ -878,12 +883,8 @@ class TestBuildScript(unittest.TestCase):
             self.dummy_index_content,
             re.DOTALL,
         )
-        dummy_header_content = (
-            header_match.group(0) if header_match else "<header></header>"
-        )
-        dummy_footer_content = (
-            footer_match.group(0) if footer_match else "<footer></footer>"
-        )
+        _ = header_match.group(0) if header_match else "<header></header>"
+        _ = footer_match.group(0) if footer_match else "<footer></footer>"
 
         # mock_extract_parts.return_value = ( # No longer needed as the function is not called
         #     "<html><head_content/></head><body>",
@@ -895,14 +896,10 @@ class TestBuildScript(unittest.TestCase):
             "<html><body>Assembled Page Content</body></html>"
         )
 
-        def mock_builtin_open_side_effect(
-            filename, mode="r", *args, **kwargs
-        ):
+        def mock_builtin_open_side_effect(filename, mode="r", *args, **kwargs):
             normalized_filename = os.path.normpath(filename)
             if mode == "r":
-                if normalized_filename.startswith(
-                    os.path.join("blocks")
-                ):
+                if normalized_filename.startswith(os.path.join("blocks")):
                     block_name = os.path.basename(filename)
                     placeholder_map = {
                         "hero.html": "{{hero_content}}",
@@ -913,17 +910,13 @@ class TestBuildScript(unittest.TestCase):
                         "contact-form.html": "{{contact_form_attributes}}",
                     }
                     return mock.mock_open(
-                        read_data=(
-                            f"<div>{placeholder_map.get(block_name, '')}</div>"
-                        )
+                        read_data=(f"<div>{placeholder_map.get(block_name, '')}</div>")
                     ).return_value
                 if normalized_filename == "index.html":
                     return mock.mock_open(
                         read_data=self.dummy_index_content
                     ).return_value
-                if normalized_filename == os.path.join(
-                    "public", "config.json"
-                ):
+                if normalized_filename == os.path.join("public", "config.json"):
                     return mock.mock_open(
                         read_data=json.dumps(self.dummy_config)
                     ).return_value
@@ -954,13 +947,9 @@ class TestBuildScript(unittest.TestCase):
         build_main()
 
         expected_paths = [
-            os.path.join(
-                "public", "generated_configs", "config_en.json"
-            ),
+            os.path.join("public", "generated_configs", "config_en.json"),
             "index.html",
-            os.path.join(
-                "public", "generated_configs", "config_es.json"
-            ),
+            os.path.join("public", "generated_configs", "config_es.json"),
             "index_es.html",
         ]
         expected_write_calls = [
@@ -969,9 +958,7 @@ class TestBuildScript(unittest.TestCase):
         ]
 
         actual_write_calls = [
-            c
-            for c in mock_builtin_open.call_args_list
-            if c.args[1] == "w"
+            c for c in mock_builtin_open.call_args_list if c.args[1] == "w"
         ]
 
         self.assertEqual(
@@ -982,9 +969,7 @@ class TestBuildScript(unittest.TestCase):
 
         for expected_call in expected_write_calls:
             normalized_actual_calls = [
-                mock.call(
-                    os.path.normpath(c.args[0]), *c.args[1:], **c.kwargs
-                )
+                mock.call(os.path.normpath(c.args[0]), *c.args[1:], **c.kwargs)
                 for c in actual_write_calls
             ]
             self.assertIn(
@@ -1004,17 +989,13 @@ class TestBuildScript(unittest.TestCase):
         self.assertEqual(mock_generate_lang_config.call_count, 2)
 
         num_langs = len(self.dummy_config["supported_langs"])
-        # Each lang processes: 1 header, 1 footer, and N blocks
-        num_blocks_in_config = len(
-            self.dummy_config.get("blocks", [])
-        )  # Use .get for safety
-        # After refactor, translate_html_content is only called for header and footer
-        # for each language, not for each block.
+
         expected_translate_calls = num_langs * 2
         self.assertEqual(
-            mock_translate_content.call_count, expected_translate_calls,
+            mock_translate_content.call_count,
+            expected_translate_calls,
             f"Expected {expected_translate_calls} calls to translate_html_content, "
-            f"got {mock_translate_content.call_count}"
+            f"got {mock_translate_content.call_count}",
         )
 
 

--- a/test_minimal.py
+++ b/test_minimal.py
@@ -1,5 +1,5 @@
-import pytest
 from google.protobuf import json_format
+
 
 def test_protobuf_import():
     assert json_format is not None

--- a/test_minimal.py
+++ b/test_minimal.py
@@ -1,0 +1,5 @@
+import pytest
+from google.protobuf import json_format
+
+def test_protobuf_import():
+    assert json_format is not None


### PR DESCRIPTION
- Corrected Jinja2 template paths for dummy templates in test setup.
- Removed mock and assertion for obsolete 'extract_base_html_parts' method.
- Ensured protobuf Python stubs are correctly generated by explicitly listing .proto files, resolving a globbing issue.
- Addressed ModuleNotFoundError for 'google.protobuf' during pytest collection by ensuring tests run with the correct Python interpreter and environment (using 'python -m pytest').
- Updated mock call count assertion for 'translate_html_content' in 'test_main_function_creates_files' to reflect refactored code.
- Added missing early-exit guards for empty/None data to HTML generator classes in 'build_protocols/html_generation.py'.
- Aligned dummy HTML templates in 'test_build.py' with the context variables and structure expected by the HTML generators and test assertions.
- Reinstalled dependencies to resolve issues with 'grpc_tools.protoc' and 'pytest' module discovery after earlier package manipulations.