### PR TITLE
Refactor/build logic and translation

### DIFF
--- a/build_protocols/interfaces.py
+++ b/build_protocols/interfaces.py
@@ -178,29 +178,10 @@ class PageBuilder(Protocol):
     from its constituent parts.
     """
 
-    def extract_base_html_parts(
-        self, base_html_path: str = "index.html"
-    ) -> Tuple[str, str, str, str]:
-        """Extracts structural parts from a base HTML template file.
-
-        Typically, this involves splitting the base HTML into segments like
-        (html_start, header, footer, html_end).
-
-        Args:
-            base_html_path: Path to the base HTML template file.
-                            Defaults to "index.html".
-
-        Returns:
-            A tuple of strings representing the distinct parts of the HTML
-            template (e.g., start, header, footer, end).
-        """
-        ...
-
     def assemble_translated_page(
         self,
         lang: str,
         translations: Translations,
-        html_parts: Tuple[str, str, str, str],
         main_content: str,
         navigation_items: Optional[List[Dict[str, Any]]] = None,
         page_title: Optional[str] = None,

--- a/build_protocols/interfaces.py
+++ b/build_protocols/interfaces.py
@@ -8,7 +8,7 @@ caching can be used interchangeably as long as they adhere to these defined
 contracts.
 """
 
-from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Protocol, Type, TypeVar, Union
 
 from google.protobuf.message import Message
 

--- a/build_protocols/page_assembly.py
+++ b/build_protocols/page_assembly.py
@@ -7,7 +7,7 @@ main content, and language-specific attributes to form a complete HTML page.
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from jinja2 import Environment
 

--- a/build_protocols/page_assembly.py
+++ b/build_protocols/page_assembly.py
@@ -41,32 +41,10 @@ class DefaultPageBuilder(PageBuilder):
         self.translation_provider = translation_provider
         self.jinja_env = jinja_env
 
-    def extract_base_html_parts(
-        self, base_html_path: str = "index.html"
-    ) -> Tuple[str, str, str, str]:
-        """
-        Extracts key structural parts from the base HTML file.
-        NOTE: This method is now largely obsolete with Jinja2 managing the base structure.
-        It's kept to satisfy the protocol but should ideally be removed or re-evaluated
-        if the PageBuilder protocol changes. For now, it returns dummy values
-        as the main assembly logic is in `assemble_translated_page` using Jinja.
-        """
-        logger.warning(
-            "extract_base_html_parts is called but is largely obsolete "
-            "with Jinja2 templating. Returning dummy values."
-        )
-        # These parts are no longer extracted this way.
-        # The base.html Jinja template defines these sections.
-        # Returning placeholder values to satisfy the interface.
-        # The actual header/footer content for the template will be passed
-        # directly to assemble_translated_page or handled within base.html itself.
-        return ("", "", "", "")
-
     def assemble_translated_page(
         self,
         lang: str,
         translations: Translations,
-        html_parts: Tuple[str, str, str, str],  # This argument is now less relevant
         main_content: str,
         navigation_items: Optional[
             List[Dict[str, Any]]
@@ -78,8 +56,6 @@ class DefaultPageBuilder(PageBuilder):
         Args:
             lang: The language code (e.g., "en").
             translations: A dictionary of translations for the language.
-            html_parts: A tuple from `extract_base_html_parts`.
-                        NOTE: Largely ignored due to Jinja2 templating.
             main_content: The HTML string for the main content of the page
                           (already rendered blocks).
             navigation_items: Optional list of navigation item dictionaries for the header.

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <header>
       <nav>
         <div class="logo">
-          <a href="#">Logo</a>
+          <a href="#" data-i18n="logo_text">Logo</a>
         </div>
         <button
           aria-expanded="false"
@@ -198,11 +198,88 @@
           </div>
         </div>
       </section>
+      <section class="contact-form" id="contact">
+        <h2 data-i18n="contact_title">Contact Us</h2>
+        <form
+          id="contactForm"
+          method="POST"
+          action="https://formspree.io/f/xgvyddyg"
+          data-form-action-url="https://formspree.io/f/xgvyddyg"
+          data-success-message="Message sent successfully! Thank you."
+          data-error-message="Oops! Something went wrong. Please try again."
+        >
+          <label for="name" data-i18n="contact_name_label">Name:</label>
+          <input type="text" id="name" name="name" required />
+
+          <label for="email" data-i18n="contact_email_label">Email:</label>
+          <input type="email" id="email" name="email" required />
+
+          <label for="message" data-i18n="contact_message_label"
+            >Message:</label
+          >
+          <textarea id="message" name="message" rows="4" required></textarea>
+
+          <button type="submit" data-i18n="contact_send_button">
+            Send Message
+          </button>
+          <div id="contactFormStatus" role="status"></div>
+        </form>
+      </section>
+
+      <script>
+        document.addEventListener("DOMContentLoaded", function () {
+          const form = document.getElementById("contactForm");
+          if (form) {
+            const statusDiv = document.getElementById("contactFormStatus");
+            // These are now read from the form's data attributes, which are set by Jinja2
+            const actionUrl = form.dataset.formActionUrl;
+            const successMessage = form.dataset.successMessage;
+            const errorMessage = form.dataset.errorMessage;
+
+            form.addEventListener("submit", function (event) {
+              event.preventDefault();
+              const formData = new FormData(form);
+              statusDiv.textContent = "";
+              statusDiv.classList.remove("success", "error");
+
+              fetch(actionUrl, {
+                method: "POST",
+                body: formData,
+                headers: {
+                  Accept: "application/json",
+                },
+              })
+                .then((response) => {
+                  if (response.ok) {
+                    statusDiv.textContent = successMessage;
+                    statusDiv.classList.add("success");
+                    form.reset();
+                  } else {
+                    response.json().then((data) => {
+                      if (Object.hasOwn(data, "errors")) {
+                        statusDiv.textContent = data["errors"]
+                          .map((error) => error["message"])
+                          .join(", ");
+                      } else {
+                        statusDiv.textContent = errorMessage;
+                      }
+                      statusDiv.classList.add("error");
+                    });
+                  }
+                })
+                .catch((error) => {
+                  statusDiv.textContent = errorMessage;
+                  statusDiv.classList.add("error");
+                });
+            });
+          }
+        });
+      </script>
     </main>
 
     <footer>
       <p data-i18n="footer_text">
-        &amp;copy; 2023 Simple Landing Page. All rights reserved.
+        &amp;copy; 2024 Simple Landing Page. All rights reserved.
       </p>
     </footer>
     <script>

--- a/index_es.html
+++ b/index_es.html
@@ -20,11 +20,11 @@
     <header>
       <nav>
         <div class="logo">
-          <a href="#">Logo</a>
+          <a href="#" data-i18n="logo_text">Logo ES</a>
         </div>
         <button
           aria-expanded="false"
-          aria-label="Toggle menu"
+          aria-label="Alternar menú"
           class="hamburger-menu"
         >
           <span class="hamburger-bar"></span>
@@ -196,11 +196,90 @@
           </div>
         </div>
       </section>
+      <section class="contact-form" id="contact">
+        <h2 data-i18n="contact_title">Contáctanos</h2>
+        <form
+          id="contactForm"
+          method="POST"
+          action="https://formspree.io/f/xgvyddyg"
+          data-form-action-url="https://formspree.io/f/xgvyddyg"
+          data-success-message="¡Mensaje enviado con éxito! Gracias."
+          data-error-message="¡Ups! Algo salió mal. Por favor, inténtalo de nuevo."
+        >
+          <label for="name" data-i18n="contact_name_label">Nombre:</label>
+          <input type="text" id="name" name="name" required />
+
+          <label for="email" data-i18n="contact_email_label"
+            >Correo Electrónico:</label
+          >
+          <input type="email" id="email" name="email" required />
+
+          <label for="message" data-i18n="contact_message_label"
+            >Mensaje:</label
+          >
+          <textarea id="message" name="message" rows="4" required></textarea>
+
+          <button type="submit" data-i18n="contact_send_button">
+            Enviar Mensaje
+          </button>
+          <div id="contactFormStatus" role="status"></div>
+        </form>
+      </section>
+
+      <script>
+        document.addEventListener("DOMContentLoaded", function () {
+          const form = document.getElementById("contactForm");
+          if (form) {
+            const statusDiv = document.getElementById("contactFormStatus");
+            // These are now read from the form's data attributes, which are set by Jinja2
+            const actionUrl = form.dataset.formActionUrl;
+            const successMessage = form.dataset.successMessage;
+            const errorMessage = form.dataset.errorMessage;
+
+            form.addEventListener("submit", function (event) {
+              event.preventDefault();
+              const formData = new FormData(form);
+              statusDiv.textContent = "";
+              statusDiv.classList.remove("success", "error");
+
+              fetch(actionUrl, {
+                method: "POST",
+                body: formData,
+                headers: {
+                  Accept: "application/json",
+                },
+              })
+                .then((response) => {
+                  if (response.ok) {
+                    statusDiv.textContent = successMessage;
+                    statusDiv.classList.add("success");
+                    form.reset();
+                  } else {
+                    response.json().then((data) => {
+                      if (Object.hasOwn(data, "errors")) {
+                        statusDiv.textContent = data["errors"]
+                          .map((error) => error["message"])
+                          .join(", ");
+                      } else {
+                        statusDiv.textContent = errorMessage;
+                      }
+                      statusDiv.classList.add("error");
+                    });
+                  }
+                })
+                .catch((error) => {
+                  statusDiv.textContent = errorMessage;
+                  statusDiv.classList.add("error");
+                });
+            });
+          }
+        });
+      </script>
     </main>
 
     <footer>
       <p data-i18n="footer_text">
-        &amp;copy; 2023 Simple Landing Page. All rights reserved.
+        &amp;copy; 2024 Página de Destino Simple. Todos los derechos reservados.
       </p>
     </footer>
     <script>

--- a/public/config.json
+++ b/public/config.json
@@ -4,9 +4,42 @@
     "features.html",
     "testimonials.html",
     "portfolio.html",
-    "blog.html"
+    "blog.html",
+    "contact-form.html"
   ],
   "navigation_data_file": "data/navigation.json",
   "supported_langs": ["en", "es"],
-  "default_lang": "en"
+  "default_lang": "en",
+  "block_data_loaders": {
+    "portfolio.html": {
+      "data_file": "data/portfolio_items.json",
+      "message_type_name": "PortfolioItem",
+      "is_list": true
+    },
+    "blog.html": {
+      "data_file": "data/blog_posts.json",
+      "message_type_name": "BlogPost",
+      "is_list": true
+    },
+    "features.html": {
+      "data_file": "data/feature_items.json",
+      "message_type_name": "FeatureItem",
+      "is_list": true
+    },
+    "testimonials.html": {
+      "data_file": "data/testimonial_items.json",
+      "message_type_name": "TestimonialItem",
+      "is_list": true
+    },
+    "hero.html": {
+      "data_file": "data/hero_item.json",
+      "message_type_name": "HeroItem",
+      "is_list": false
+    },
+    "contact-form.html": {
+      "data_file": "data/contact_form_config.json",
+      "message_type_name": "ContactFormConfig",
+      "is_list": false
+    }
+  }
 }

--- a/public/generated_configs/config_en.json
+++ b/public/generated_configs/config_en.json
@@ -4,11 +4,44 @@
     "features.html",
     "testimonials.html",
     "portfolio.html",
-    "blog.html"
+    "blog.html",
+    "contact-form.html"
   ],
   "navigation_data_file": "data/navigation.json",
   "supported_langs": ["en", "es"],
   "default_lang": "en",
+  "block_data_loaders": {
+    "portfolio.html": {
+      "data_file": "data/portfolio_items.json",
+      "message_type_name": "PortfolioItem",
+      "is_list": true
+    },
+    "blog.html": {
+      "data_file": "data/blog_posts.json",
+      "message_type_name": "BlogPost",
+      "is_list": true
+    },
+    "features.html": {
+      "data_file": "data/feature_items.json",
+      "message_type_name": "FeatureItem",
+      "is_list": true
+    },
+    "testimonials.html": {
+      "data_file": "data/testimonial_items.json",
+      "message_type_name": "TestimonialItem",
+      "is_list": true
+    },
+    "hero.html": {
+      "data_file": "data/hero_item.json",
+      "message_type_name": "HeroItem",
+      "is_list": false
+    },
+    "contact-form.html": {
+      "data_file": "data/contact_form_config.json",
+      "message_type_name": "ContactFormConfig",
+      "is_list": false
+    }
+  },
   "navigation": [
     {
       "label_i18n_key": "nav_home",
@@ -99,8 +132,10 @@
     "light_mode_toggle": "Toggle Light Mode",
     "theme_light_button": "Light Theme",
     "theme_dark_button": "Dark Theme",
-    "footer_text": "&copy; 2023 Simple Landing Page. All rights reserved.",
+    "footer_text": "&copy; 2024 Simple Landing Page. All rights reserved.",
     "contact_form_success": "Message sent successfully! Thank you.",
-    "contact_form_error": "Oops! Something went wrong. Please try again."
+    "contact_form_error": "Oops! Something went wrong. Please try again.",
+    "logo_text": "Logo",
+    "toggle_menu_label": "Toggle menu"
   }
 }

--- a/public/generated_configs/config_es.json
+++ b/public/generated_configs/config_es.json
@@ -4,11 +4,44 @@
     "features.html",
     "testimonials.html",
     "portfolio.html",
-    "blog.html"
+    "blog.html",
+    "contact-form.html"
   ],
   "navigation_data_file": "data/navigation.json",
   "supported_langs": ["en", "es"],
   "default_lang": "en",
+  "block_data_loaders": {
+    "portfolio.html": {
+      "data_file": "data/portfolio_items.json",
+      "message_type_name": "PortfolioItem",
+      "is_list": true
+    },
+    "blog.html": {
+      "data_file": "data/blog_posts.json",
+      "message_type_name": "BlogPost",
+      "is_list": true
+    },
+    "features.html": {
+      "data_file": "data/feature_items.json",
+      "message_type_name": "FeatureItem",
+      "is_list": true
+    },
+    "testimonials.html": {
+      "data_file": "data/testimonial_items.json",
+      "message_type_name": "TestimonialItem",
+      "is_list": true
+    },
+    "hero.html": {
+      "data_file": "data/hero_item.json",
+      "message_type_name": "HeroItem",
+      "is_list": false
+    },
+    "contact-form.html": {
+      "data_file": "data/contact_form_config.json",
+      "message_type_name": "ContactFormConfig",
+      "is_list": false
+    }
+  },
   "navigation": [
     {
       "label_i18n_key": "nav_home",
@@ -99,8 +132,10 @@
     "light_mode_toggle": "Alternar Modo Claro",
     "theme_light_button": "Tema Claro",
     "theme_dark_button": "Tema Oscuro",
-    "footer_text": "&copy; 2023 Página de Destino Simple. Todos los derechos reservados.",
+    "footer_text": "&copy; 2024 Página de Destino Simple. Todos los derechos reservados.",
     "contact_form_success": "¡Mensaje enviado con éxito! Gracias.",
-    "contact_form_error": "¡Ups! Algo salió mal. Por favor, inténtalo de nuevo."
+    "contact_form_error": "¡Ups! Algo salió mal. Por favor, inténtalo de nuevo.",
+    "logo_text": "Logo ES",
+    "toggle_menu_label": "Alternar menú"
   }
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -62,5 +62,8 @@
   "theme_dark_button": "Dark Theme",
   "footer_text": "&copy; 2023 Simple Landing Page. All rights reserved.",
   "contact_form_success": "Message sent successfully! Thank you.",
-  "contact_form_error": "Oops! Something went wrong. Please try again."
+  "contact_form_error": "Oops! Something went wrong. Please try again.",
+  "logo_text": "Logo",
+  "toggle_menu_label": "Toggle menu",
+  "footer_text": "&copy; 2024 Simple Landing Page. All rights reserved."
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -62,5 +62,8 @@
   "theme_dark_button": "Tema Oscuro",
   "footer_text": "&copy; 2023 Página de Destino Simple. Todos los derechos reservados.",
   "contact_form_success": "¡Mensaje enviado con éxito! Gracias.",
-  "contact_form_error": "¡Ups! Algo salió mal. Por favor, inténtalo de nuevo."
+  "contact_form_error": "¡Ups! Algo salió mal. Por favor, inténtalo de nuevo.",
+  "logo_text": "Logo ES",
+  "toggle_menu_label": "Alternar menú",
+  "footer_text": "&copy; 2024 Página de Destino Simple. Todos los derechos reservados."
 }

--- a/templates/blocks/footer.html
+++ b/templates/blocks/footer.html
@@ -1,5 +1,6 @@
 <footer>
   <p data-i18n="footer_text">
-    &amp;copy; 2023 Simple Landing Page. All rights reserved.
+    {{ translations.get('footer_text', '&copy; 2024 Simple Landing Page. All
+    rights reserved.') }}
   </p>
 </footer>

--- a/templates/blocks/header.html
+++ b/templates/blocks/header.html
@@ -1,11 +1,13 @@
 <header>
   <nav>
     <div class="logo">
-      <a href="#">Logo</a>
+      <a href="#" data-i18n="logo_text"
+        >{{ translations.get('logo_text', 'Logo') }}</a
+      >
     </div>
     <button
       aria-expanded="false"
-      aria-label="Toggle menu"
+      aria-label="{{ translations.get('toggle_menu_label', 'Toggle menu') }}"
       class="hamburger-menu"
     >
       <span class="hamburger-bar"></span>


### PR DESCRIPTION
- Moved block data loader configuration from hardcoded Python dict to `public/config.json`.
- Updated `BuildOrchestrator` to load and resolve this configuration.
- Ensured Jinja templates consistently use the `translations` object for server-side rendering in header, footer, and blocks.
- Added new translation keys to locale files for header/footer elements.
- Removed obsolete `extract_base_html_parts` method from `PageBuilder` interface and implementation, updating call sites.