### PR TITLE
Add 3 AI experimental feature ideas to roadmap

### DIFF
--- a/docs/feature_ideas.md
+++ b/docs/feature_ideas.md
@@ -421,3 +421,96 @@ The following ideas were generated during a recent analysis session. They are pr
         - No spam protection inherent to this method.
 
 ---
+
+### 11. AI-Powered Personalized Content Blocks
+
+- **Priority**: Experimental
+- **Impact**: High
+- **Effort**: High
+- **Concept**: Dynamically adapt content within various sections of the landing page (e.g., Hero, Features, Testimonials) to better resonate with different anticipated user personas or segments. For a static site generator, this could mean generating multiple distinct versions of the site, each tailored to a specific persona.
+- **AI Aspect**:
+    - **Persona-Based Content Generation**: An AI (e.g., a large language model like GPT) could be prompted with persona details (e.g., "tech-savvy early adopter," "budget-conscious small business owner") and existing baseline content for a block. The AI would then rewrite or generate new content (headlines, descriptions, calls to action) specifically tailored to that persona's likely interests, pain points, and language.
+    - **Content Curation/Selection**: If a predefined set of content variations exists, an AI could help classify them or assist in selecting the most appropriate variation for a given persona during the build configuration for a persona-specific site version.
+- **Benefits**:
+    - Increased relevance and engagement by speaking more directly to specific user groups.
+    - Potentially higher conversion rates by addressing persona-specific needs and motivations.
+    - Allows for more targeted marketing campaigns by directing different personas to their tailored landing page versions.
+- **High-Level Implementation Sketch**:
+    1.  **Persona Definition**: Users define target personas (e.g., in a new `personas.json` file or through an interface).
+    2.  **Content Input**: Baseline content for each block is provided as usual (e.g., in `data/feature_items.json`).
+    3.  **AI Integration (Build Time)**:
+        *   During `build.py`, for each defined persona and for each relevant content block:
+            *   The build script sends the baseline content and persona description to an AI model API.
+            *   The AI returns tailored content.
+        *   The build process then generates a separate version of the site (e.g., `index_persona_A.html`, `index_persona_B.html`) using this AI-generated content.
+    4.  **Data Structure**: Protobuf messages might need a way to store multiple content variations per item, perhaps tagged by persona.
+- **Potential Challenges/Experimental Nature**:
+    - **Cost and Speed**: Frequent calls to powerful AI models can be expensive and slow down the build process significantly.
+    - **Content Quality Control**: AI-generated content needs careful review to ensure accuracy, brand alignment, and avoidance of biases or nonsensical text.
+    - **Over-Personalization**: Risk of creating overly narrow or stereotypical content.
+    - **Complexity**: Managing multiple site versions adds complexity.
+
+---
+
+### 12. Generative Component Styling (AI-SADS)
+
+- **Priority**: Experimental
+- **Impact**: Medium
+- **Effort**: High
+- **Concept**: Leverage AI to assist in designing the visual appearance of components by generating or suggesting Semantic Attribute-Driven Styling (SADS) attributes. Users could describe their desired aesthetic or functional style in natural language, and the AI would translate this into concrete `data-sads-*` attributes for the component's HTML.
+- **AI Aspect**:
+    - **Natural Language to SADS Translation**: An AI model (potentially a fine-tuned LLM or a model trained on code/markup generation) would take a natural language prompt (e.g., "Make this feature list look sleek and professional with high contrast for readability") and the component's basic HTML structure as input.
+    - **SADS Attribute Generation**: The AI would output a set of `data-sads-*` attributes to be applied to the HTML elements within the component, consistent with the SADS system's capabilities (defined in `sads-default-theme.js` and `sads-style-engine.js`).
+    - **Iterative Refinement**: The system could allow users to iteratively refine the AI's suggestions.
+- **Benefits**:
+    - Lowers the barrier to styling and theming, allowing users less familiar with CSS or SADS syntax to achieve desired looks.
+    - Accelerates the design process by providing quick visual prototypes.
+    - Encourages experimentation with the SADS system by showing its expressive potential.
+- **High-Level Implementation Sketch**:
+    1.  **Interface (CLI or Build-time Config)**: A way for users to input their natural language styling prompts for specific components.
+    2.  **AI Model Interaction**:
+        *   The system sends the prompt and relevant HTML snippet (and potentially the SADS theme definition as context) to an AI model.
+        *   The AI returns suggested `data-sads-*` attributes or modified HTML with these attributes.
+    3.  **Template Update**: The suggested attributes are either manually or automatically applied to the component's HTML template file.
+    4.  **SADS Engine**: The existing SADS engine (`public/js/sads-style-engine.js`) would then render these AI-generated attributes.
+- **Potential Challenges/Experimental Nature**:
+    - **SADS Expressiveness Limits**: The AI can only generate styles that the SADS engine and theme actually support. The current SADS is an MVP.
+    - **Model Training/Fine-Tuning**: A general-purpose LLM might struggle with the specific syntax and semantics of SADS without fine-tuning or very detailed prompting.
+    - **Determinism and Consistency**: Getting consistent and high-quality styling suggestions can be challenging.
+    - **User Interface for Interaction**: Creating an effective UI for prompting and refining styles would be key.
+
+---
+
+### 13. AI-Driven Content & SEO Audit
+
+- **Priority**: Experimental
+- **Impact**: High
+- **Effort**: Medium-High
+- **Concept**: Integrate AI-powered analysis into the build process to audit the website's text content for quality, readability, SEO effectiveness, and translation consistency. The build would produce a report with actionable insights and suggestions.
+- **AI Aspect**:
+    - **Natural Language Processing (NLP)**: Utilize AI models for:
+        - **Readability Analysis**: Calculate scores and suggest simplifications.
+        - **SEO Keyword Analysis**: Identify keywords, assess density, suggest related LSI keywords.
+        - **Tone and Sentiment Analysis**: Evaluate if content tone aligns with brand voice.
+        - **Grammar and Style Checks**: Beyond basic spell checking.
+        - **Translation Quality (for i18n)**: Preliminary assessment of translation accuracy and fluency.
+- **Benefits**:
+    - Improves content quality, making it more engaging and easier to understand.
+    - Enhances SEO, potentially leading to better search engine rankings.
+    - Helps maintain a consistent brand voice and translation quality.
+    - Automates parts of the content review process.
+- **High-Level Implementation Sketch**:
+    1.  **Content Extraction**: During `build.py`, extract all relevant text content.
+    2.  **AI Analysis Service**:
+        *   Create a module (e.g., `ContentAuditor`) to interface with AI NLP APIs.
+        *   Send extracted text for analysis based on configured checks.
+    3.  **Configuration**: `public/config.json` could have an `ai_audit_config` section.
+    4.  **Report Generation**: Build process outputs a report (e.g., `ai_content_audit.html` or console output) with findings and suggestions.
+- **Potential Challenges/Experimental Nature**:
+    - **Cost of APIs**: NLP APIs can be costly for large amounts of text.
+    - **Actionability of Suggestions**: AI suggestions might be generic or require human interpretation.
+    - **Contextual Understanding**: AI may lack deep contextual understanding of the specific business domain.
+    - **Integration Complexity**: Managing API calls and consolidating results can be complex.
+    - **False Positives/Negatives**: AI assessment can be subjective.
+
+---


### PR DESCRIPTION
This commit adds three new AI-driven experimental feature ideas to the `docs/feature_ideas.md` document:

1.  **AI-Powered Personalized Content Blocks**: Generating persona-specific content for site sections.
2.  **Generative Component Styling (AI-SADS)**: Using AI to generate SADS attributes from natural language descriptions.
3.  **AI-Driven Content & SEO Audit**: Analyzing content for readability, SEO, tone, and translation quality during the build process.