### PR TITLE
Fix: Update GitHub Actions workflow to use Go build process

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,7 +1,9 @@
-name: Jekyll site CI
+name: Go Build and Deploy
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 on:
   push:
@@ -12,39 +14,48 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          python-version: "3.11" # Specify a Python version
+          go-version: '1.21' # Specify your Go version
 
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' # Specify your Node.js version
 
-      - name: Run generate-proto to generate PROTO files
-        run: mkdir -p generated && python -m grpc_tools.protoc -I./proto --python_out=./generated --pyi_out=./generated ./proto/*.proto && touch generated/__init__.py
+      - name: Install JavaScript dependencies
+        run: npm install
 
-      - name: Patch generated proto files for relative imports
-        run: |
-          for f in generated/*_pb2.py; do
-            if [ -f "$f" ]; then
-              sed -i 's/^import common_pb2 as common__pb2/from . import common_pb2 as common__pb2/' "$f"
-            fi
-          done
+      - name: Build the site
+        run: npm run build
 
-      - name: Run build.py to generate HTML files
-        run: python build.py
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
-      - name: Build the site in the jekyll/builder container
-        run: |
-          docker run \
-          -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-          jekyll/builder:4 /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload repository root (for index.html, index_es.html, etc.)
+          # and public/dist (for assets), public/generated_configs (for lang configs)
+          path: |
+            .
+            public/dist
+            public/generated_configs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Removed Python and Jekyll build steps.
- Added Go and Node.js setup.
- Updated build commands to use npm scripts.
- Configured GitHub Pages deployment for the Go build artifacts.